### PR TITLE
docs: standardise spec version to 1.0.9 and fix broken references

### DIFF
--- a/.agents/hello-world-agent.yaml
+++ b/.agents/hello-world-agent.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.0.8"
+open_agent_spec: "1.0.9"
 
 agent:
   name: hello-world-agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - This changelog.
+- **Agents-as-code documentation** — new section in REFERENCE.md explaining the `.agents/` pattern, bundled examples table, and scaffold/run/generate workflows.
+- Agents-as-code overview section in README.md with link to REFERENCE.md.
+- "Adding an agent-as-code example" guide in CONTRIBUTING.md.
+- Codex engine configuration reference (sandbox modes, cwd) in REFERENCE.md.
 
 ### Changed
 - Standardised spec version to `1.0.9` across all examples, templates, and docs (CONTRIBUTING.md, README.md, `.agents/`, Website content).
 - README quick-start YAML now includes the required `open_agent_spec` version field.
+- Added required `type: llm` field to all `intelligence` examples in README.md and REFERENCE.md (field is required by schema but was missing from docs).
 
 ### Fixed
 - Removed broken references to non-existent `security-threat-analyzer.yaml` template and `SECURITY_TEMPLATES.md` from REFERENCE.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This changelog.
 
 ### Changed
-- (none yet)
+- Standardised spec version to `1.0.9` across all examples, templates, and docs (CONTRIBUTING.md, README.md, `.agents/`, Website content).
+- README quick-start YAML now includes the required `open_agent_spec` version field.
+
+### Fixed
+- Removed broken references to non-existent `security-threat-analyzer.yaml` template and `SECURITY_TEMPLATES.md` from REFERENCE.md.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The Open Agent Spec (OA) uses YAML files to define agent configurations. Use the
 
 #### Basic Structure
 ```yaml
-open_agent_spec: "1.0.8"
+open_agent_spec: "1.0.9"
 
 agent:
   name: my-agent
@@ -33,7 +33,7 @@ intelligence:
 
 #### Required Fields
 
-1. **`open_agent_spec`**: Version of the OA specification (string, e.g. `"1.0.8"`).
+1. **`open_agent_spec`**: Version of the OA specification (string, e.g. `"1.0.9"`).
 
 2. **`agent`** section:
    - `name`: A unique identifier for your agent (kebab-case; will be converted to snake_case for Python)
@@ -52,7 +52,7 @@ intelligence:
 
 1. Trading Agent:
 ```yaml
-open_agent_spec: "1.0.8"
+open_agent_spec: "1.0.9"
 
 agent:
   name: market-analyzer
@@ -71,7 +71,7 @@ intelligence:
 
 2. Content Generator:
 ```yaml
-open_agent_spec: "1.0.8"
+open_agent_spec: "1.0.9"
 
 agent:
   name: content-creator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,17 @@ intelligence:
 
 Add a new YAML spec under `oas_cli/templates/` (e.g. `my-template.yaml`). For `oa init --template minimal`-style usage, the CLI loads from that directory; For custom YAML use `oa init --spec path/to/your.yaml`. Overriding the template directory (e.g. via an env var) is not currently supported. Document the template in the README “Built-in Templates” section.
 
+#### Adding an agent-as-code example
+
+To add a new `.agents/` example to the repository:
+
+1. Create a YAML spec in `.agents/` following the standard spec structure (see examples in that directory).
+2. Make sure `open_agent_spec`, `agent`, `intelligence` (including `type: llm`), `tasks`, and `prompts` are all present and valid.
+3. Validate with `oa init --spec .agents/your-agent.yaml --output /tmp/test --dry-run`.
+4. Document the agent in the table in [docs/REFERENCE.md](docs/REFERENCE.md#bundled-examples) under “Agents as code”.
+
+See the existing `.agents/ci-failure-repair.yaml` for a production-quality example that is wired into a GitHub Actions workflow.
+
 ### Reporting Bugs
 
 - Check if the bug has already been reported in the Issues section

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ export OPENAI_API_KEY=your_api_key_here
 Create an agent spec:
 
 ```yaml
+open_agent_spec: "1.0.9"
+
 agent:
   name: hello-world-agent
   role: chat

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ agent:
   role: chat
 
 intelligence:
+  type: llm
   engine: openai
   model: gpt-4
 
@@ -95,6 +96,21 @@ Run the agent directly from the spec:
 ```bash
 oa run --spec agent.yaml --task greet --input '{"name":"Alice"}' --quiet
 ```
+
+---
+
+# Agents as Code
+
+Store specs in a `.agents/` directory at the repo root — like `.github/workflows/` but for agents. Run them directly, or generate code from them.
+
+```bash
+oa init aac                          # scaffold .agents/ with an example spec
+oa run --spec .agents/example.yaml --task greet --input '{"name":"CI"}' --quiet
+```
+
+This repo's own `.agents/` directory includes a [CI failure repair agent](.agents/ci-failure-repair.yaml) that is called from a GitHub Actions workflow to auto-fix lint and formatting issues.
+
+See [docs/REFERENCE.md](docs/REFERENCE.md#agents-as-code-agents) for details and bundled examples.
 
 ---
 

--- a/Website/content/defaultSpec.yaml
+++ b/Website/content/defaultSpec.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.0.8"
+open_agent_spec: "1.0.9"
 
 agent:
   name: hello-world-agent

--- a/Website/content/researchAssistantSpec.yaml
+++ b/Website/content/researchAssistantSpec.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.0.8"
+open_agent_spec: "1.0.9"
 
 agent:
   name: research-assistant

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -133,12 +133,10 @@ Other YAMLs ship inside the package; from a clone you can do:
 
 ```bash
 oa init --spec oas_cli/templates/minimal-multi-task-agent.yaml --output my-multi-agent/
-oa init --spec oas_cli/templates/security-threat-analyzer.yaml --output threat-analyzer/
+oa init --spec oas_cli/templates/minimal-agent-tool-usage.yaml --output tool-agent/
 ```
 
 Or point `--spec` at any file on disk.
-
-Security-focused templates and notes: [oas_cli/templates/SECURITY_TEMPLATES.md](../oas_cli/templates/SECURITY_TEMPLATES.md).
 
 ## Development
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -13,6 +13,7 @@ agent:
   role: "chat"   # optional: analyst, reviewer, chat, retriever, planner, executor
 
 intelligence:
+  type: "llm"
   engine: "openai"   # openai | anthropic | grok | cortex | codex | local | custom
   endpoint: "https://api.openai.com/v1"
   model: "gpt-4"
@@ -58,6 +59,7 @@ behavioural_contract:
 
 ```yaml
 intelligence:
+  type: "llm"
   engine: "openai"
   endpoint: "https://api.openai.com/v1"
   model: "gpt-4"
@@ -68,6 +70,7 @@ intelligence:
 
 ```yaml
 intelligence:
+  type: "llm"
   engine: "anthropic"
   endpoint: "https://api.anthropic.com"
   model: "claude-3-sonnet-20240229"
@@ -78,15 +81,33 @@ intelligence:
 
 ```yaml
 intelligence:
+  type: "llm"
   engine: "grok"
   endpoint: "https://api.x.ai/v1"
   model: "grok-3-latest"
 ```
 
+### Codex
+
+Runs [Codex CLI](https://github.com/openai/codex) non-interactively via the built-in adapter (`oas_cli/adapters/codex_adapter.py`). Requires `codex` on `PATH` and `codex login`.
+
+```yaml
+intelligence:
+  type: "llm"
+  engine: "codex"
+  model: "gpt-4.1-codex"
+  config:
+    sandbox: "workspace-write"   # codex sandbox mode
+    cwd: "."                     # working directory for codex exec
+```
+
+`config` keys are passed as CLI flags to `codex exec`. Common options: `sandbox` (`workspace-write`, `workspace-read`, `none`) and `cwd`.
+
 ### Custom router
 
 ```yaml
 intelligence:
+  type: "llm"
   engine: "custom"
   endpoint: "http://localhost:1234/invoke"
   model: "my-model"
@@ -106,6 +127,42 @@ class CustomLLMRouter:
     def run(self, prompt: str, **kwargs) -> str:
         return json.dumps({"response": f"…"})
 ```
+
+## Agents as code (`.agents/`)
+
+The **agent-as-code** pattern stores spec files in a `.agents/` directory at the root of your repository — similar to how `.github/workflows/` stores CI pipelines. Specs in `.agents/` are treated as infrastructure-as-code: check them into version control, run them directly with `oa run`, or generate full project scaffolds from them.
+
+### Scaffold the layout
+
+```bash
+oa init aac                          # creates .agents/example.yaml + README
+oa init aac --directory ./my-repo    # target a different root
+```
+
+### Run an agent directly
+
+```bash
+oa run --spec .agents/hello-world-agent.yaml --task greet \
+  --input '{"name":"Alice"}' --quiet
+```
+
+### Generate code from an agent spec
+
+```bash
+oa init --spec .agents/ci-failure-repair.yaml --output ./repair-agent
+```
+
+### Bundled examples
+
+This repository ships three `.agents/` specs as working examples:
+
+| File | Role | Engine | Description |
+|------|------|--------|-------------|
+| `hello-world-agent.yaml` | chat | openai | Simple greeting — good starting point |
+| `ci-failure-repair.yaml` | analyst | openai | Diagnoses GitHub Actions failures and emits remediation commands. Used by `.github/workflows/ci-failure-repair.yml` in this repo. |
+| `codex-runner.yaml` | executor | codex | Runs Codex CLI non-interactively for arbitrary instructions |
+
+---
 
 ## Generated project layout
 


### PR DESCRIPTION
- Update open_agent_spec from 1.0.8 to 1.0.9 across CONTRIBUTING.md,
  .agents/hello-world-agent.yaml, and Website content specs
- Add missing open_agent_spec version field to README quick-start example
- Remove broken references to non-existent security-threat-analyzer.yaml
  and SECURITY_TEMPLATES.md from REFERENCE.md
- Update CHANGELOG with housekeeping changes