### PR TITLE
feat: remove sdk provider independence

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -354,15 +354,17 @@ A contract violation on a dependency stops the chain immediately and raises `CON
 
 ## Engines (quick)
 
-| Engine | Env var (typical) |
-|--------|-------------------|
-| openai | `OPENAI_API_KEY` |
-| anthropic | `ANTHROPIC_API_KEY` |
-| grok | `XAI_API_KEY` |
-| cortex | `OPENAI_API_KEY`, `CLAUDE_API_KEY` + `cortex-intelligence` |
-| codex | Codex CLI (`codex` on PATH; `codex login`) |
-| local | placeholder |
-| custom | Your router class: `__init__(endpoint, model, config)`, `run(prompt, **kwargs)` → JSON string |
+| Engine | Env var | Notes |
+|--------|---------|-------|
+| `openai` | `OPENAI_API_KEY` | Chat Completions or Responses API |
+| `anthropic` | `ANTHROPIC_API_KEY` | Messages API |
+| `grok` / `xai` | `XAI_API_KEY` | OpenAI-compatible; routes to `api.x.ai` |
+| `cortex` | `OPENAI_API_KEY` | OpenAI-compatible; set `endpoint` in spec |
+| `local` | _(none)_ | OpenAI-compatible local server (Ollama, LM Studio, …) |
+| `codex` | Codex CLI on PATH | `codex login` required |
+| `custom` | _(user-defined)_ | HTTP endpoint or Python class via `module:` |
+
+All engines except `anthropic` and `codex` speak the OpenAI Chat Completions API. `oa run` uses raw HTTP — no SDK required.
 
 ### OpenAI
 
@@ -371,8 +373,8 @@ intelligence:
   type: "llm"
   engine: "openai"
   endpoint: "https://api.openai.com/v1"
-  model: "gpt-4"
-  config: { temperature: 0.7, max_tokens: 150 }
+  model: "gpt-4o"
+  config: { temperature: 0.7, max_tokens: 1000 }
 ```
 
 ### Anthropic
@@ -382,18 +384,64 @@ intelligence:
   type: "llm"
   engine: "anthropic"
   endpoint: "https://api.anthropic.com"
-  model: "claude-3-sonnet-20240229"
-  config: { temperature: 0.7, max_tokens: 150 }
+  model: "claude-3-5-sonnet-20241022"
+  config: { temperature: 0.7, max_tokens: 1000 }
 ```
 
-### Grok (xAI, OpenAI-compatible client)
+### Grok / xAI (OpenAI-compatible)
+
+`engine: grok` and `engine: xai` are aliases — both route to `https://api.x.ai/v1` with `XAI_API_KEY`. Endpoint and model can be overridden in the spec.
 
 ```yaml
 intelligence:
   type: "llm"
-  engine: "grok"
-  endpoint: "https://api.x.ai/v1"
-  model: "grok-3-latest"
+  engine: "grok"          # or "xai"
+  model: "grok-3-latest"  # default; override as needed
+```
+
+```bash
+export XAI_API_KEY=xai-...
+```
+
+### Cortex (OpenAI-compatible, user-hosted)
+
+`cortex` is treated as an OpenAI-compatible endpoint. Provide your `endpoint` in the spec; `OPENAI_API_KEY` is used by default but can be overridden via `config.api_key_env`.
+
+```yaml
+intelligence:
+  type: "llm"
+  engine: "cortex"
+  endpoint: "https://cortex.mycompany.com/v1"
+  model: "my-cortex-model"
+  config:
+    api_key_env: "CORTEX_API_KEY"
+```
+
+### Local LLM (Ollama, LM Studio, vLLM, …)
+
+`engine: local` points to a local OpenAI-compatible server. No API key is required. The default endpoint is `http://localhost:11434/v1` (Ollama). Override `endpoint` and `model` as needed.
+
+```yaml
+intelligence:
+  type: "llm"
+  engine: "local"
+  model: "llama3.2"     # default; match whatever model you have pulled
+```
+
+```bash
+# Start Ollama (example)
+ollama serve
+ollama pull llama3.2
+```
+
+To use a different local server (e.g. LM Studio on port 1234):
+
+```yaml
+intelligence:
+  type: "llm"
+  engine: "local"
+  endpoint: "http://localhost:1234/v1"
+  model: "mistral-7b"
 ```
 
 ### Codex
@@ -414,27 +462,51 @@ intelligence:
 
 ### Custom router
 
+Two modes:
+
+**HTTP mode** — no Python glue, just an OpenAI-compatible endpoint:
+
+```yaml
+intelligence:
+  type: "llm"
+  engine: "custom"
+  endpoint: "https://my-llm-proxy.internal/v1"
+  model: "my-model"
+```
+
+**Class mode** — point to a Python class for full control:
+
 ```yaml
 intelligence:
   type: "llm"
   engine: "custom"
   endpoint: "http://localhost:1234/invoke"
   model: "my-model"
-  module: "CustomLLMRouter.CustomLLMRouter"
+  module: "my_package.router.MyRouter"
 ```
 
-```python
-# CustomLLMRouter.py
-import json
+The class must implement:
 
-class CustomLLMRouter:
-    def __init__(self, endpoint: str, model: str, config: dict):
+```python
+class MyRouter:
+    def __init__(self, endpoint: str, model: str, config: dict): ...
+    def run(self, prompt: str, **kwargs) -> str: ...  # returns JSON string
+```
+
+Example:
+
+```python
+# my_package/router.py
+import json, requests
+
+class MyRouter:
+    def __init__(self, endpoint, model, config):
         self.endpoint = endpoint
         self.model = model
-        self.config = config
 
-    def run(self, prompt: str, **kwargs) -> str:
-        return json.dumps({"response": f"…"})
+    def run(self, prompt, **kwargs):
+        resp = requests.post(self.endpoint, json={"prompt": prompt, "model": self.model})
+        return resp.text  # must be a JSON string
 ```
 
 ## Agents as code (`.agents/`)

--- a/oas_cli/providers/__init__.py
+++ b/oas_cli/providers/__init__.py
@@ -1,0 +1,12 @@
+"""OAS intelligence providers — raw-HTTP, no-SDK implementations."""
+
+from .base import EngineNotSupportedError, IntelligenceProvider, ProviderError
+from .registry import get_provider, invoke_intelligence
+
+__all__ = [
+    "IntelligenceProvider",
+    "ProviderError",
+    "EngineNotSupportedError",
+    "get_provider",
+    "invoke_intelligence",
+]

--- a/oas_cli/providers/__init__.py
+++ b/oas_cli/providers/__init__.py
@@ -1,12 +1,14 @@
 """OAS intelligence providers — raw-HTTP, no-SDK implementations."""
 
 from .base import EngineNotSupportedError, IntelligenceProvider, ProviderError
+from .custom import CustomProvider
 from .registry import get_provider, invoke_intelligence
 
 __all__ = [
     "IntelligenceProvider",
     "ProviderError",
     "EngineNotSupportedError",
+    "CustomProvider",
     "get_provider",
     "invoke_intelligence",
 ]

--- a/oas_cli/providers/anthropic_http.py
+++ b/oas_cli/providers/anthropic_http.py
@@ -1,0 +1,74 @@
+"""Anthropic provider — raw HTTP, no SDK dependency."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .base import IntelligenceProvider, ProviderError
+
+_DEFAULT_ENDPOINT = "https://api.anthropic.com/v1/messages"
+_DEFAULT_MODEL = "claude-3-5-sonnet-20241022"
+_ANTHROPIC_VERSION = "2023-06-01"
+
+
+class AnthropicProvider(IntelligenceProvider):
+    """Calls Anthropic Claude via raw HTTP — no anthropic SDK required.
+
+    Reads ANTHROPIC_API_KEY from the environment (or api_key_env in the spec).
+    """
+
+    def invoke(self, *, system: str, user: str, config: dict) -> str:
+        api_key_env = config.get("api_key_env", "ANTHROPIC_API_KEY")
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            raise ProviderError(
+                f"Anthropic API key not set — export {api_key_env} or set "
+                "intelligence.config.api_key_env in your spec."
+            )
+
+        endpoint = config.get("endpoint", _DEFAULT_ENDPOINT)
+        if not endpoint.endswith("/messages"):
+            endpoint = endpoint.rstrip("/") + "/messages"
+
+        model = config.get("model", _DEFAULT_MODEL)
+        temperature = float(config.get("temperature", 0.7))
+        max_tokens = int(config.get("max_tokens", 1000))
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": user}],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if system:
+            payload["system"] = system
+
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+
+        body = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            endpoint, data=body, headers=headers, method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                data = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            raise ProviderError(f"Anthropic HTTP {exc.code}: {detail}") from exc
+        except Exception as exc:
+            raise ProviderError(f"Anthropic request failed: {exc}") from exc
+
+        try:
+            return data["content"][0]["text"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ProviderError(
+                f"Unexpected Anthropic response shape: {data}"
+            ) from exc

--- a/oas_cli/providers/anthropic_http.py
+++ b/oas_cli/providers/anthropic_http.py
@@ -11,7 +11,10 @@ from typing import Any
 from .base import IntelligenceProvider, ProviderError
 
 _DEFAULT_ENDPOINT = "https://api.anthropic.com/v1/messages"
+# TODO: model names go stale — consider requiring specs to always declare
+#       intelligence.model explicitly and dropping this fallback entirely.
 _DEFAULT_MODEL = "claude-3-5-sonnet-20241022"
+_DEFAULT_TIMEOUT = 60
 _ANTHROPIC_VERSION = "2023-06-01"
 
 
@@ -37,6 +40,7 @@ class AnthropicProvider(IntelligenceProvider):
         model = config.get("model", _DEFAULT_MODEL)
         temperature = float(config.get("temperature", 0.7))
         max_tokens = int(config.get("max_tokens", 1000))
+        timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
 
         payload: dict[str, Any] = {
             "model": model,
@@ -58,7 +62,7 @@ class AnthropicProvider(IntelligenceProvider):
             endpoint, data=body, headers=headers, method="POST"
         )
         try:
-            with urllib.request.urlopen(req, timeout=60) as resp:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode(errors="replace")

--- a/oas_cli/providers/anthropic_http.py
+++ b/oas_cli/providers/anthropic_http.py
@@ -69,6 +69,4 @@ class AnthropicProvider(IntelligenceProvider):
         try:
             return data["content"][0]["text"]
         except (KeyError, IndexError, TypeError) as exc:
-            raise ProviderError(
-                f"Unexpected Anthropic response shape: {data}"
-            ) from exc
+            raise ProviderError(f"Unexpected Anthropic response shape: {data}") from exc

--- a/oas_cli/providers/base.py
+++ b/oas_cli/providers/base.py
@@ -1,0 +1,37 @@
+"""Base class and exception types for OAS intelligence providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class ProviderError(RuntimeError):
+    """Raised when a provider call fails (HTTP error, bad response shape, etc.)."""
+
+
+class EngineNotSupportedError(ProviderError):
+    """Raised when no provider is registered for the requested engine."""
+
+
+class IntelligenceProvider(ABC):
+    """Minimal interface every provider must implement.
+
+    OAS handles prompt construction, task orchestration, and output parsing.
+    A provider's only job is: take (system, user, config) → return raw string.
+    """
+
+    @abstractmethod
+    def invoke(self, *, system: str, user: str, config: dict) -> str:
+        """Invoke the model and return the raw text response.
+
+        Args:
+            system: System prompt.
+            user:   User message (template already rendered).
+            config: Provider config dict from intelligence_config (model, temperature, …).
+
+        Returns:
+            Raw string output from the model — no parsing.
+
+        Raises:
+            ProviderError: On any HTTP or response-shape failure.
+        """

--- a/oas_cli/providers/codex.py
+++ b/oas_cli/providers/codex.py
@@ -1,0 +1,29 @@
+"""Codex CLI provider — delegates to the existing codex_adapter."""
+
+from __future__ import annotations
+
+from .base import IntelligenceProvider, ProviderError
+
+
+class CodexProvider(IntelligenceProvider):
+    """Routes invocations through the Codex CLI adapter.
+
+    Merges system and user into a single prompt string because the codex adapter
+    accepts a flat prompt rather than separate roles.
+    """
+
+    def invoke(self, *, system: str, user: str, config: dict) -> str:
+        try:
+            from oas_cli.adapters import (
+                codex_adapter,  # local import avoids circular dep
+            )
+        except ImportError as exc:
+            raise ProviderError("codex_adapter is not available in this environment") from exc
+
+        combined = f"{system}\n\n{user}".strip() if system else user
+        result = codex_adapter.invoke(combined, config)
+        if isinstance(result, str):
+            return result
+        # codex_adapter may return a dict — normalise to string for the runner
+        import json
+        return json.dumps(result)

--- a/oas_cli/providers/codex.py
+++ b/oas_cli/providers/codex.py
@@ -18,7 +18,9 @@ class CodexProvider(IntelligenceProvider):
                 codex_adapter,  # local import avoids circular dep
             )
         except ImportError as exc:
-            raise ProviderError("codex_adapter is not available in this environment") from exc
+            raise ProviderError(
+                "codex_adapter is not available in this environment"
+            ) from exc
 
         combined = f"{system}\n\n{user}".strip() if system else user
         result = codex_adapter.invoke(combined, config)
@@ -26,4 +28,5 @@ class CodexProvider(IntelligenceProvider):
             return result
         # codex_adapter may return a dict — normalise to string for the runner
         import json
+
         return json.dumps(result)

--- a/oas_cli/providers/custom.py
+++ b/oas_cli/providers/custom.py
@@ -1,0 +1,83 @@
+"""Custom provider — supports user-supplied Python router classes.
+
+When ``intelligence.module`` is set in the spec, the named class is
+dynamically imported and called.  The expected interface is:
+
+    class MyRouter:
+        def __init__(self, endpoint: str, model: str, config: dict): ...
+        def run(self, prompt: str, **kwargs) -> str: ...   # returns JSON string
+
+When ``module`` is absent the provider falls back to the ``OpenAIProvider``
+(OpenAI-compatible HTTP), so a bare ``engine: custom`` with only an
+``endpoint`` works without any Python glue code.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from .base import IntelligenceProvider, ProviderError
+
+
+class CustomProvider(IntelligenceProvider):
+    """Routes to a user-supplied Python class, or falls back to HTTP."""
+
+    def invoke(self, *, system: str, user: str, config: dict) -> str:
+        module_path: str | None = config.get("module")
+
+        if not module_path:
+            # No module specified — behave as a plain OpenAI-compatible endpoint.
+            from .openai_http import OpenAIProvider
+
+            return OpenAIProvider().invoke(system=system, user=user, config=config)
+
+        return self._invoke_class(module_path, system, user, config)
+
+    @staticmethod
+    def _invoke_class(module_path: str, system: str, user: str, config: dict) -> str:
+        """Dynamically load ``module_path`` and call ``run()`` on an instance."""
+        if "." not in module_path:
+            raise ProviderError(
+                f"intelligence.module must be 'module.ClassName', got: '{module_path}'"
+            )
+
+        module_name, class_name = module_path.rsplit(".", 1)
+        try:
+            mod = importlib.import_module(module_name)
+        except ImportError as exc:
+            raise ProviderError(
+                f"Cannot import module '{module_name}' (from intelligence.module={module_path!r}): {exc}"
+            ) from exc
+
+        cls = getattr(mod, class_name, None)
+        if cls is None:
+            raise ProviderError(
+                f"Class '{class_name}' not found in module '{module_name}'"
+            )
+
+        endpoint = config.get("endpoint", "")
+        model = config.get("model", "")
+        try:
+            router = cls(endpoint=endpoint, model=model, config=config)
+        except Exception as exc:
+            raise ProviderError(
+                f"Failed to instantiate {module_path}(endpoint, model, config): {exc}"
+            ) from exc
+
+        # The legacy interface takes a single merged prompt string.
+        prompt = f"{system}\n\n{user}".strip() if system else user
+        try:
+            result = router.run(prompt)
+        except Exception as exc:
+            raise ProviderError(f"{module_path}.run() raised: {exc}") from exc
+
+        if not isinstance(result, str):
+            import json
+
+            try:
+                return json.dumps(result)
+            except Exception as exc:
+                raise ProviderError(
+                    f"{module_path}.run() returned non-string, non-serialisable value: {type(result)}"
+                ) from exc
+        return result

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -1,0 +1,120 @@
+"""OpenAI provider — raw HTTP, no SDK dependency."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .base import IntelligenceProvider, ProviderError
+
+# Default to the Chat Completions API; set intelligence.endpoint in your spec
+# to switch to the Responses API (https://api.openai.com/v1/responses) or a
+# compatible endpoint (Azure, local proxy, etc.).
+_DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+_DEFAULT_MODEL = "gpt-4o"
+
+
+class OpenAIProvider(IntelligenceProvider):
+    """Calls OpenAI via raw HTTP — no openai SDK required.
+
+    Reads OPENAI_API_KEY from the environment (or api_key_env in the spec).
+    """
+
+    def invoke(self, *, system: str, user: str, config: dict) -> str:
+        api_key_env = config.get("api_key_env", "OPENAI_API_KEY")
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            raise ProviderError(
+                f"OpenAI API key not set — export {api_key_env} or set "
+                "intelligence.config.api_key_env in your spec."
+            )
+
+        endpoint = config.get("endpoint", _DEFAULT_ENDPOINT)
+        # Accept bare base URL (e.g. https://api.openai.com/v1) — append path.
+        if not endpoint.endswith("/chat/completions") and not endpoint.endswith("/responses"):
+            endpoint = endpoint.rstrip("/") + "/chat/completions"
+
+        model = config.get("model", _DEFAULT_MODEL)
+        temperature = float(config.get("temperature", 0.7))
+        max_tokens = int(config.get("max_tokens", 1000))
+
+        if endpoint.endswith("/responses"):
+            payload = _build_responses_payload(system, user, model, temperature)
+        else:
+            payload = _build_chat_completions_payload(
+                system, user, model, temperature, max_tokens
+            )
+
+        return _http_post(endpoint, payload, headers={"Authorization": f"Bearer {api_key}"})
+
+
+def _build_chat_completions_payload(
+    system: str, user: str, model: str, temperature: float, max_tokens: int
+) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+
+
+def _build_responses_payload(
+    system: str, user: str, model: str, temperature: float
+) -> dict[str, Any]:
+    return {
+        "model": model,
+        "input": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "temperature": temperature,
+    }
+
+
+def _http_post(url: str, payload: dict, headers: dict) -> str:
+    all_headers = {
+        "Content-Type": "application/json",
+        **headers,
+    }
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=body, headers=all_headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise ProviderError(f"OpenAI HTTP {exc.code}: {detail}") from exc
+    except Exception as exc:
+        raise ProviderError(f"OpenAI request failed: {exc}") from exc
+
+    return _extract_text(data, url)
+
+
+def _extract_text(data: dict, url: str) -> str:
+    """Extract the text content from a Chat Completions or Responses API response."""
+    # Responses API shape: data["output"][0]["content"][0]["text"]
+    if "output" in data:
+        try:
+            return data["output"][0]["content"][0]["text"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ProviderError(
+                f"Unexpected OpenAI Responses API shape: {data}"
+            ) from exc
+
+    # Chat Completions shape: data["choices"][0]["message"]["content"]
+    if "choices" in data:
+        try:
+            return data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ProviderError(
+                f"Unexpected OpenAI Chat Completions shape: {data}"
+            ) from exc
+
+    raise ProviderError(f"Unrecognised OpenAI response shape from {url}: {data}")

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -24,12 +24,16 @@ class OpenAIProvider(IntelligenceProvider):
     """
 
     def invoke(self, *, system: str, user: str, config: dict) -> str:
-        api_key_env = config.get("api_key_env", "OPENAI_API_KEY")
-        api_key = os.environ.get(api_key_env)
-        if not api_key:
+        api_key_env: str | None = config.get("api_key_env", "OPENAI_API_KEY")
+        api_key: str | None = os.environ.get(api_key_env) if api_key_env else None
+
+        # Require a key only when the config explicitly names an env var and it's absent.
+        # Local / anonymous endpoints (api_key_env=None or "") skip this check.
+        if api_key_env and not api_key:
             raise ProviderError(
-                f"OpenAI API key not set — export {api_key_env} or set "
-                "intelligence.config.api_key_env in your spec."
+                f"API key not set — export {api_key_env} or set "
+                "intelligence.config.api_key_env in your spec. "
+                "For local/unauthenticated endpoints set api_key_env to null."
             )
 
         endpoint = config.get("endpoint", _DEFAULT_ENDPOINT)
@@ -50,9 +54,11 @@ class OpenAIProvider(IntelligenceProvider):
                 system, user, model, temperature, max_tokens
             )
 
-        return _http_post(
-            endpoint, payload, headers={"Authorization": f"Bearer {api_key}"}
-        )
+        extra_headers: dict[str, str] = {}
+        if api_key:
+            extra_headers["Authorization"] = f"Bearer {api_key}"
+
+        return _http_post(endpoint, payload, headers=extra_headers)
 
 
 def _build_chat_completions_payload(

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -92,7 +92,9 @@ def _build_responses_payload(
     }
 
 
-def _http_post(url: str, payload: dict, headers: dict, timeout: int = _DEFAULT_TIMEOUT) -> str:
+def _http_post(
+    url: str, payload: dict, headers: dict, timeout: int = _DEFAULT_TIMEOUT
+) -> str:
     all_headers = {
         "Content-Type": "application/json",
         **headers,

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -14,7 +14,10 @@ from .base import IntelligenceProvider, ProviderError
 # to switch to the Responses API (https://api.openai.com/v1/responses) or a
 # compatible endpoint (Azure, local proxy, etc.).
 _DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+# TODO: model names go stale — consider requiring specs to always declare
+#       intelligence.model explicitly and dropping this fallback entirely.
 _DEFAULT_MODEL = "gpt-4o"
+_DEFAULT_TIMEOUT = 60
 
 
 class OpenAIProvider(IntelligenceProvider):
@@ -46,6 +49,7 @@ class OpenAIProvider(IntelligenceProvider):
         model = config.get("model", _DEFAULT_MODEL)
         temperature = float(config.get("temperature", 0.7))
         max_tokens = int(config.get("max_tokens", 1000))
+        timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
 
         if endpoint.endswith("/responses"):
             payload = _build_responses_payload(system, user, model, temperature)
@@ -58,7 +62,7 @@ class OpenAIProvider(IntelligenceProvider):
         if api_key:
             extra_headers["Authorization"] = f"Bearer {api_key}"
 
-        return _http_post(endpoint, payload, headers=extra_headers)
+        return _http_post(endpoint, payload, headers=extra_headers, timeout=timeout)
 
 
 def _build_chat_completions_payload(
@@ -88,7 +92,7 @@ def _build_responses_payload(
     }
 
 
-def _http_post(url: str, payload: dict, headers: dict) -> str:
+def _http_post(url: str, payload: dict, headers: dict, timeout: int = _DEFAULT_TIMEOUT) -> str:
     all_headers = {
         "Content-Type": "application/json",
         **headers,
@@ -96,7 +100,7 @@ def _http_post(url: str, payload: dict, headers: dict) -> str:
     body = json.dumps(payload).encode()
     req = urllib.request.Request(url, data=body, headers=all_headers, method="POST")
     try:
-        with urllib.request.urlopen(req, timeout=60) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -34,7 +34,9 @@ class OpenAIProvider(IntelligenceProvider):
 
         endpoint = config.get("endpoint", _DEFAULT_ENDPOINT)
         # Accept bare base URL (e.g. https://api.openai.com/v1) — append path.
-        if not endpoint.endswith("/chat/completions") and not endpoint.endswith("/responses"):
+        if not endpoint.endswith("/chat/completions") and not endpoint.endswith(
+            "/responses"
+        ):
             endpoint = endpoint.rstrip("/") + "/chat/completions"
 
         model = config.get("model", _DEFAULT_MODEL)
@@ -48,7 +50,9 @@ class OpenAIProvider(IntelligenceProvider):
                 system, user, model, temperature, max_tokens
             )
 
-        return _http_post(endpoint, payload, headers={"Authorization": f"Bearer {api_key}"})
+        return _http_post(
+            endpoint, payload, headers={"Authorization": f"Bearer {api_key}"}
+        )
 
 
 def _build_chat_completions_payload(

--- a/oas_cli/providers/registry.py
+++ b/oas_cli/providers/registry.py
@@ -30,7 +30,7 @@ _OPENAI_COMPAT_DEFAULTS: dict[str, dict] = {
     # These expose an OpenAI-compatible API; no key required by default.
     "local": {
         "endpoint": "http://localhost:11434/v1",
-        "api_key_env": None,   # no auth for local servers
+        "api_key_env": None,  # no auth for local servers
         "model": "llama3.2",
     },
     # Cortex — user-hosted or enterprise; user must supply endpoint in spec.
@@ -100,7 +100,9 @@ def invoke_intelligence(system: str, user: str, config: dict) -> str:
     # Spec values always win: defaults fill gaps, never override explicit config.
     resolved = {**defaults, **config}
     provider = get_provider(resolved)
-    return _with_retry(lambda: provider.invoke(system=system, user=user, config=resolved))
+    return _with_retry(
+        lambda: provider.invoke(system=system, user=user, config=resolved)
+    )
 
 
 def _with_retry(fn: Callable[[], str], retries: int = 2, delay: float = 1.0) -> str:

--- a/oas_cli/providers/registry.py
+++ b/oas_cli/providers/registry.py
@@ -1,0 +1,74 @@
+"""Provider registry — maps engine names to provider instances."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+from .anthropic_http import AnthropicProvider
+from .base import EngineNotSupportedError, IntelligenceProvider, ProviderError
+from .codex import CodexProvider
+from .openai_http import OpenAIProvider
+
+
+def get_provider(config: dict) -> IntelligenceProvider:
+    """Return the provider for the engine named in *config*.
+
+    Args:
+        config: Intelligence config dict (keys: engine, model, endpoint, …).
+
+    Raises:
+        EngineNotSupportedError: If the engine is not recognised.
+    """
+    engine = (config.get("engine") or "openai").lower()
+
+    if engine == "openai":
+        return OpenAIProvider()
+    if engine == "anthropic":
+        return AnthropicProvider()
+    if engine == "codex":
+        return CodexProvider()
+
+    raise EngineNotSupportedError(
+        f"Unknown engine '{engine}'. Supported: openai, anthropic, codex."
+    )
+
+
+def invoke_intelligence(system: str, user: str, config: dict) -> str:
+    """Select the right provider and call it with retry.
+
+    This is the single call-site that ``oas_cli.runner`` uses. It keeps the
+    runner decoupled from every individual provider.
+
+    Args:
+        system: System prompt string.
+        user:   Rendered user prompt string.
+        config: Intelligence config produced by ``_build_intelligence_config``.
+
+    Returns:
+        Raw string response from the model.
+
+    Raises:
+        ProviderError: Propagated from the underlying provider.
+        EngineNotSupportedError: If the engine is not recognised.
+    """
+    provider = get_provider(config)
+    return _with_retry(lambda: provider.invoke(system=system, user=user, config=config))
+
+
+def _with_retry(fn: Callable[[], str], retries: int = 2, delay: float = 1.0) -> str:
+    """Call *fn* up to ``retries + 1`` times, sleeping *delay* s between attempts.
+
+    Only retries on ``ProviderError`` (transient HTTP failures).
+    ``EngineNotSupportedError`` and other exceptions are re-raised immediately.
+    """
+    for attempt in range(retries + 1):
+        try:
+            return fn()
+        except EngineNotSupportedError:
+            raise
+        except ProviderError:
+            if attempt == retries:
+                raise
+            time.sleep(delay)
+    raise RuntimeError("unreachable")  # pragma: no cover

--- a/oas_cli/providers/registry.py
+++ b/oas_cli/providers/registry.py
@@ -8,7 +8,42 @@ from collections.abc import Callable
 from .anthropic_http import AnthropicProvider
 from .base import EngineNotSupportedError, IntelligenceProvider, ProviderError
 from .codex import CodexProvider
+from .custom import CustomProvider
 from .openai_http import OpenAIProvider
+
+# Per-engine defaults applied before the spec config (spec values always win).
+# All engines in this table are routed to OpenAIProvider (OpenAI-compatible HTTP).
+_OPENAI_COMPAT_DEFAULTS: dict[str, dict] = {
+    # Grok / xAI — OpenAI-compatible endpoint at api.x.ai
+    "grok": {
+        "endpoint": "https://api.x.ai/v1",
+        "api_key_env": "XAI_API_KEY",
+        "model": "grok-3-latest",
+    },
+    # xai is an alias for grok (same company / same API)
+    "xai": {
+        "endpoint": "https://api.x.ai/v1",
+        "api_key_env": "XAI_API_KEY",
+        "model": "grok-3-latest",
+    },
+    # Local LLMs (Ollama, LM Studio, vLLM, llama.cpp server, …)
+    # These expose an OpenAI-compatible API; no key required by default.
+    "local": {
+        "endpoint": "http://localhost:11434/v1",
+        "api_key_env": None,   # no auth for local servers
+        "model": "llama3.2",
+    },
+    # Cortex — user-hosted or enterprise; user must supply endpoint in spec.
+    # api_key_env defaults to OPENAI_API_KEY but can be overridden.
+    "cortex": {
+        "api_key_env": "OPENAI_API_KEY",
+    },
+    # Custom — falls through to CustomProvider; no defaults needed here.
+    "custom": {},
+}
+
+# Engines that are fully OpenAI-compatible (no specialised provider class needed)
+_OPENAI_COMPAT_ENGINES = frozenset({"grok", "xai", "local", "cortex"})
 
 
 def get_provider(config: dict) -> IntelligenceProvider:
@@ -16,6 +51,8 @@ def get_provider(config: dict) -> IntelligenceProvider:
 
     Args:
         config: Intelligence config dict (keys: engine, model, endpoint, …).
+                Engine-specific defaults have already been merged in by
+                ``invoke_intelligence`` before this is called.
 
     Raises:
         EngineNotSupportedError: If the engine is not recognised.
@@ -28,17 +65,23 @@ def get_provider(config: dict) -> IntelligenceProvider:
         return AnthropicProvider()
     if engine == "codex":
         return CodexProvider()
+    if engine in _OPENAI_COMPAT_ENGINES:
+        return OpenAIProvider()
+    if engine == "custom":
+        return CustomProvider()
 
     raise EngineNotSupportedError(
-        f"Unknown engine '{engine}'. Supported: openai, anthropic, codex."
+        f"Unknown engine '{engine}'. "
+        "Supported: openai, anthropic, grok, xai, local, cortex, custom, codex."
     )
 
 
 def invoke_intelligence(system: str, user: str, config: dict) -> str:
     """Select the right provider and call it with retry.
 
-    This is the single call-site that ``oas_cli.runner`` uses. It keeps the
-    runner decoupled from every individual provider.
+    Engine-specific defaults are applied here so that ``get_provider`` and the
+    provider itself always see a fully-resolved config (spec values win over
+    defaults — later dict keys win in Python's ``{**defaults, **config}``).
 
     Args:
         system: System prompt string.
@@ -52,8 +95,12 @@ def invoke_intelligence(system: str, user: str, config: dict) -> str:
         ProviderError: Propagated from the underlying provider.
         EngineNotSupportedError: If the engine is not recognised.
     """
-    provider = get_provider(config)
-    return _with_retry(lambda: provider.invoke(system=system, user=user, config=config))
+    engine = (config.get("engine") or "openai").lower()
+    defaults = _OPENAI_COMPAT_DEFAULTS.get(engine, {})
+    # Spec values always win: defaults fill gaps, never override explicit config.
+    resolved = {**defaults, **config}
+    provider = get_provider(resolved)
+    return _with_retry(lambda: provider.invoke(system=system, user=user, config=resolved))
 
 
 def _with_retry(fn: Callable[[], str], retries: int = 2, delay: float = 1.0) -> str:

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import yaml
 
-from .runtime import invoke_intelligence
+from .providers import ProviderError, invoke_intelligence
 
 logger = logging.getLogger(__name__)
 
@@ -120,20 +120,23 @@ def _choose_task(
     return first_name, tasks[first_name]
 
 
-def _build_prompt(
+def _resolve_prompts(
     spec_data: dict[str, Any],
     task_name: str,
     input_data: dict[str, Any],
     override_system: str | None = None,
     override_user: str | None = None,
-) -> str:
-    """Build the prompt for a task using a layered resolution order.
+) -> tuple[str, str]:
+    """Resolve the system and user prompts for a task (layered resolution).
 
     Priority (highest → lowest):
       1. CLI overrides  (override_system / override_user)
       2. Per-task inline prompts  tasks.<name>.prompts  (Style A — preferred)
       3. Per-task map prompts     prompts.<name>.system/user  (Style B — legacy)
       4. Global fallback          prompts.system / prompts.user
+
+    Returns:
+        (system, user) — both are plain strings, user already rendered.
     """
     # Style A — prompts block co-located inside the task definition
     tasks = spec_data.get("tasks") or {}
@@ -173,6 +176,24 @@ def _build_prompt(
         placeholder_input = "{{ input." + key + " }}"
         user = user.replace(placeholder_input, str(value))
 
+    return system, user
+
+
+def _build_prompt(
+    spec_data: dict[str, Any],
+    task_name: str,
+    input_data: dict[str, Any],
+    override_system: str | None = None,
+    override_user: str | None = None,
+) -> str:
+    """Return system and user merged into a single string (for backward compat).
+
+    Prefer ``_resolve_prompts`` for new code — it keeps the roles separate so
+    providers can pass them to the model API individually.
+    """
+    system, user = _resolve_prompts(
+        spec_data, task_name, input_data, override_system, override_user
+    )
     return f"{system}\n\n{user}".strip()
 
 
@@ -338,7 +359,7 @@ def _run_single_task(
             task=task_name,
         )
 
-    prompt = _build_prompt(
+    system, user = _resolve_prompts(
         spec_data,
         task_name,
         input_data,
@@ -348,7 +369,14 @@ def _run_single_task(
     intelligence_config = _build_intelligence_config(spec_data)
 
     try:
-        raw_output = invoke_intelligence(prompt, intelligence_config)
+        raw_output = invoke_intelligence(system, user, intelligence_config)
+    except ProviderError as exc:
+        raise OARunError(
+            str(exc),
+            code="PROVIDER_ERROR",
+            stage="run",
+            task=task_name,
+        ) from exc
     except Exception as exc:
         raise OARunError(
             str(exc),
@@ -414,7 +442,7 @@ def _run_single_task(
     return {
         "task": task_name,
         "input": input_data,
-        "prompt": prompt,
+        "prompt": f"{system}\n\n{user}".strip(),
         "engine": intelligence_config.get("engine"),
         "model": intelligence_config.get("model"),
         "raw_output": raw_output,

--- a/oas_cli/schemas/oas-schema.json
+++ b/oas_cli/schemas/oas-schema.json
@@ -60,12 +60,13 @@
               "openai",
               "anthropic",
               "grok",
+              "xai",
               "cortex",
               "codex",
               "local",
               "custom"
             ],
-            "description": "LLM engine provider (e.g., openai, anthropic, grok, cortex, codex, local, custom)"
+            "description": "LLM engine provider (e.g., openai, anthropic, grok/xai, cortex, codex, local, custom)"
           },
           "model": {
             "type": "string",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,12 @@ dependencies = [
     "typer>=0.9.0",
     "pyyaml",
     "rich",
-    "openai>=1.0.0",
-    "anthropic>=0.3.0",
     "jinja2>=3.0.0",
     "setuptools>=69.0.0",
     "jsonschema>=4.0.0",
     "python-dotenv>=0.19.0",
     "tomli>=1.0.0; python_version < '3.11'",
-    # Runtime: oas_cli.runtime and `oa run` invoke DACP-backed adapters.
+    # Runtime: oas_cli.runtime and `oa init`-generated code use DACP adapters.
     "dacp>=0.3.3",
 ]
 
@@ -32,6 +30,12 @@ Repository = "https://github.com/prime-vector/open-agent-spec"
 Documentation = "https://github.com/prime-vector/open-agent-spec/blob/main/docs/REFERENCE.md"
 
 [project.optional-dependencies]
+# Install open-agent-spec[sdks] if you use `oa init`-generated projects or
+# want the full SDK experience. `oa run` uses raw HTTP and needs neither.
+sdks = [
+    "openai>=1.0.0",
+    "anthropic>=0.3.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/tests/test_contract_validation.py
+++ b/tests/test_contract_validation.py
@@ -1,11 +1,14 @@
 """Test behavioral contract validation across engines."""
 
+import importlib.util
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 pytestmark = pytest.mark.contract
+
+_anthropic_available = importlib.util.find_spec("anthropic") is not None
 
 
 class TestContractValidation:
@@ -43,6 +46,10 @@ class TestContractValidation:
         assert isinstance(content["confidence_level"], int | float)
         assert 0.0 <= content["confidence_level"] <= 1.0
 
+    @pytest.mark.skipif(
+        not _anthropic_available,
+        reason="anthropic SDK not installed (pip install open-agent-spec[sdks])",
+    )
     @patch("anthropic.Anthropic")
     def test_claude_valid_response(
         self, mock_anthropic, mock_claude_response, sample_threat_data

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -119,8 +119,8 @@ def test_run_system_prompt_override_reaches_runner(tmp_path):
     spec_file = _write_spec(tmp_path)
     captured: dict = {}
 
-    def fake_invoke(prompt: str, config: dict) -> str:
-        captured["prompt"] = prompt
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        captured["prompt"] = f"{system}\n\n{user}"
         return '{"response": "hi"}'
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -151,8 +151,8 @@ def test_run_user_prompt_override_reaches_runner(tmp_path):
     spec_file = _write_spec(tmp_path)
     captured: dict = {}
 
-    def fake_invoke(prompt: str, config: dict) -> str:
-        captured["prompt"] = prompt
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        captured["prompt"] = f"{system}\n\n{user}"
         return '{"response": "hi"}'
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -182,8 +182,8 @@ def test_run_no_overrides_uses_per_task_prompt(tmp_path):
     spec_file = _write_spec(tmp_path)
     captured: dict = {}
 
-    def fake_invoke(prompt: str, config: dict) -> str:
-        captured["prompt"] = prompt
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        captured["prompt"] = f"{system}\n\n{user}"
         return '{"response": "hi"}'
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -210,7 +210,7 @@ def test_run_output_is_valid_json_in_quiet_mode(tmp_path):
     """oa run --quiet outputs valid JSON."""
     spec_file = _write_spec(tmp_path)
 
-    def fake_invoke(prompt: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict) -> str:
         return '{"response": "Hello Alice!"}'
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):

--- a/tests/test_multi_engine.py
+++ b/tests/test_multi_engine.py
@@ -1,5 +1,6 @@
 """Test multi-engine compatibility and consistency."""
 
+import importlib.util
 import json
 from unittest.mock import MagicMock, patch
 
@@ -7,6 +8,8 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 pytestmark = pytest.mark.multi_engine
+
+_anthropic_available = importlib.util.find_spec("anthropic") is not None
 
 
 class MockAnalyzeThreatOutput(BaseModel):
@@ -103,6 +106,10 @@ class TestEngineCompatibility:
         assert "recommendations" in parsed
         assert "confidence_level" in parsed
 
+    @pytest.mark.skipif(
+        not _anthropic_available,
+        reason="anthropic SDK not installed (pip install open-agent-spec[sdks])",
+    )
     @patch("anthropic.Anthropic")
     def test_claude_api_integration_mock(self, mock_anthropic_class):
         """Test Claude API integration with mocked responses."""

--- a/tests/test_multi_task_workflows.py
+++ b/tests/test_multi_task_workflows.py
@@ -119,8 +119,8 @@ def _run(
     """Run run_task_from_spec with a monkeypatched invoke_intelligence."""
     captured: dict = {}
 
-    def fake_invoke(prompt: str, config: dict) -> str:
-        captured["prompt"] = prompt
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        captured["prompt"] = f"{system}\n\n{user}"
         captured["config"] = config
         return fake_response
 
@@ -523,7 +523,7 @@ class TestOutputNormalisation:
         """If invoke_intelligence returns a dict, pass it straight through."""
         spec = _spec({"t": _task(system="s", user="{{ q }}")})
 
-        def fake_invoke(prompt: str, config: dict) -> dict:
+        def fake_invoke(system: str, user: str, config: dict) -> dict:
             return {"result": "direct"}
 
         with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -923,8 +923,8 @@ def _cli_run(
 ) -> object:
     captured: dict = {}
 
-    def fake_invoke(prompt: str, config: dict) -> str:
-        captured["prompt"] = prompt
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        captured["prompt"] = f"{system}\n\n{user}"
         return fake_response
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -1034,8 +1034,8 @@ class TestCLIIntegration:
         # Greet task has a single required string field — file should be accepted
         captured: dict = {}
 
-        def fake_invoke(prompt: str, config: dict) -> str:
-            captured["prompt"] = prompt
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            captured["prompt"] = f"{system}\n\n{user}"
             return '{"response": "hi"}'
 
         with patch("oas_cli.runner.invoke_intelligence", fake_invoke):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -14,7 +14,6 @@ from oas_cli.providers.custom import CustomProvider
 from oas_cli.providers.openai_http import OpenAIProvider
 from oas_cli.providers.registry import _OPENAI_COMPAT_DEFAULTS, invoke_intelligence
 
-
 # ---------------------------------------------------------------------------
 # get_provider routing
 # ---------------------------------------------------------------------------
@@ -22,20 +21,33 @@ from oas_cli.providers.registry import _OPENAI_COMPAT_DEFAULTS, invoke_intellige
 
 class TestGetProvider:
     def test_openai(self):
-        assert isinstance(get_provider({"engine": "openai", "model": "gpt-4o"}), OpenAIProvider)
+        assert isinstance(
+            get_provider({"engine": "openai", "model": "gpt-4o"}), OpenAIProvider
+        )
 
     def test_anthropic(self):
-        assert isinstance(get_provider({"engine": "anthropic", "model": "claude-3-5-sonnet-20241022"}), AnthropicProvider)
+        assert isinstance(
+            get_provider(
+                {"engine": "anthropic", "model": "claude-3-5-sonnet-20241022"}
+            ),
+            AnthropicProvider,
+        )
 
     def test_codex(self):
-        assert isinstance(get_provider({"engine": "codex", "model": "gpt-4.1-codex"}), CodexProvider)
+        assert isinstance(
+            get_provider({"engine": "codex", "model": "gpt-4.1-codex"}), CodexProvider
+        )
 
     @pytest.mark.parametrize("engine", ["grok", "xai", "local", "cortex"])
     def test_openai_compat_engines_route_to_openai_provider(self, engine):
-        assert isinstance(get_provider({"engine": engine, "model": "any"}), OpenAIProvider)
+        assert isinstance(
+            get_provider({"engine": engine, "model": "any"}), OpenAIProvider
+        )
 
     def test_custom_routes_to_custom_provider(self):
-        assert isinstance(get_provider({"engine": "custom", "model": "any"}), CustomProvider)
+        assert isinstance(
+            get_provider({"engine": "custom", "model": "any"}), CustomProvider
+        )
 
     def test_unknown_engine_raises(self):
         with pytest.raises(EngineNotSupportedError):
@@ -45,8 +57,12 @@ class TestGetProvider:
         assert isinstance(get_provider({"model": "gpt-4o"}), OpenAIProvider)
 
     def test_engine_name_is_case_insensitive(self):
-        assert isinstance(get_provider({"engine": "OPENAI", "model": "gpt-4o"}), OpenAIProvider)
-        assert isinstance(get_provider({"engine": "Grok", "model": "grok-3-latest"}), OpenAIProvider)
+        assert isinstance(
+            get_provider({"engine": "OPENAI", "model": "gpt-4o"}), OpenAIProvider
+        )
+        assert isinstance(
+            get_provider({"engine": "Grok", "model": "grok-3-latest"}), OpenAIProvider
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -130,9 +146,14 @@ class TestOpenAIProviderAuth:
             return '{"choices": [{"message": {"content": "hi"}}]}'
 
         with patch.dict("os.environ", env_vars, clear=False):
-            with patch("oas_cli.providers.openai_http._http_post", side_effect=fake_http_post):
+            with patch(
+                "oas_cli.providers.openai_http._http_post", side_effect=fake_http_post
+            ):
                 provider = OpenAIProvider()
-                config: dict = {"model": "gpt-4o", "endpoint": "https://api.openai.com/v1"}
+                config: dict = {
+                    "model": "gpt-4o",
+                    "endpoint": "https://api.openai.com/v1",
+                }
                 if api_key_env is not None:
                     config["api_key_env"] = api_key_env
                 provider.invoke(system="sys", user="usr", config=config)
@@ -155,7 +176,9 @@ class TestOpenAIProviderAuth:
             captured_headers.update(headers)
             return '{"choices": [{"message": {"content": "hi"}}]}'
 
-        with patch("oas_cli.providers.openai_http._http_post", side_effect=fake_http_post):
+        with patch(
+            "oas_cli.providers.openai_http._http_post", side_effect=fake_http_post
+        ):
             provider = OpenAIProvider()
             provider.invoke(
                 system="sys",
@@ -199,14 +222,17 @@ class TestCustomProvider:
             result = provider.invoke(
                 system="s",
                 user="u",
-                config={"engine": "custom", "model": "my-model", "endpoint": "http://x/v1"},
+                config={
+                    "engine": "custom",
+                    "model": "my-model",
+                    "endpoint": "http://x/v1",
+                },
             )
 
         assert result == '{"result": "ok"}'
 
     def test_module_class_is_called(self, tmp_path, monkeypatch):
         """A user-supplied class in sys.path is instantiated and run."""
-        import sys
 
         # Write a tiny router class to a temp file on sys.path
         router_file = tmp_path / "my_router.py"
@@ -244,7 +270,6 @@ class TestCustomProvider:
             provider.invoke(system="s", user="u", config={"module": "NoDotsHere"})
 
     def test_class_not_found_raises(self, tmp_path, monkeypatch):
-        import sys
 
         mod_file = tmp_path / "empty_mod.py"
         mod_file.write_text("# nothing here\n")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -141,7 +141,7 @@ class TestOpenAIProviderAuth:
         """Run OpenAIProvider.invoke with a mocked HTTP call and return the request headers."""
         captured_headers: dict = {}
 
-        def fake_http_post(url, payload, headers):
+        def fake_http_post(url, payload, headers, timeout=60):
             captured_headers.update(headers)
             return '{"choices": [{"message": {"content": "hi"}}]}'
 
@@ -172,7 +172,7 @@ class TestOpenAIProviderAuth:
         """Local/anonymous endpoints — explicit api_key_env=None skips auth entirely."""
         captured_headers: dict = {}
 
-        def fake_http_post(url, payload, headers):
+        def fake_http_post(url, payload, headers, timeout=60):
             captured_headers.update(headers)
             return '{"choices": [{"message": {"content": "hi"}}]}'
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,259 @@
+"""Unit tests for oas_cli/providers/ — engine routing and provider behaviour."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oas_cli.providers import EngineNotSupportedError, ProviderError, get_provider
+from oas_cli.providers.anthropic_http import AnthropicProvider
+from oas_cli.providers.codex import CodexProvider
+from oas_cli.providers.custom import CustomProvider
+from oas_cli.providers.openai_http import OpenAIProvider
+from oas_cli.providers.registry import _OPENAI_COMPAT_DEFAULTS, invoke_intelligence
+
+
+# ---------------------------------------------------------------------------
+# get_provider routing
+# ---------------------------------------------------------------------------
+
+
+class TestGetProvider:
+    def test_openai(self):
+        assert isinstance(get_provider({"engine": "openai", "model": "gpt-4o"}), OpenAIProvider)
+
+    def test_anthropic(self):
+        assert isinstance(get_provider({"engine": "anthropic", "model": "claude-3-5-sonnet-20241022"}), AnthropicProvider)
+
+    def test_codex(self):
+        assert isinstance(get_provider({"engine": "codex", "model": "gpt-4.1-codex"}), CodexProvider)
+
+    @pytest.mark.parametrize("engine", ["grok", "xai", "local", "cortex"])
+    def test_openai_compat_engines_route_to_openai_provider(self, engine):
+        assert isinstance(get_provider({"engine": engine, "model": "any"}), OpenAIProvider)
+
+    def test_custom_routes_to_custom_provider(self):
+        assert isinstance(get_provider({"engine": "custom", "model": "any"}), CustomProvider)
+
+    def test_unknown_engine_raises(self):
+        with pytest.raises(EngineNotSupportedError):
+            get_provider({"engine": "banana"})
+
+    def test_default_engine_is_openai_when_missing(self):
+        assert isinstance(get_provider({"model": "gpt-4o"}), OpenAIProvider)
+
+    def test_engine_name_is_case_insensitive(self):
+        assert isinstance(get_provider({"engine": "OPENAI", "model": "gpt-4o"}), OpenAIProvider)
+        assert isinstance(get_provider({"engine": "Grok", "model": "grok-3-latest"}), OpenAIProvider)
+
+
+# ---------------------------------------------------------------------------
+# Engine defaults applied by invoke_intelligence
+# ---------------------------------------------------------------------------
+
+
+class TestEngineDefaults:
+    """Verify _OPENAI_COMPAT_DEFAULTS are merged correctly (spec wins)."""
+
+    def _captured_invoke(self, engine: str, extra: dict | None = None):
+        """Call invoke_intelligence and capture the resolved config passed to the provider."""
+        captured: dict = {}
+
+        def fake_invoke(*, system, user, config):
+            captured.update(config)
+            return '{"ok": true}'
+
+        base = {"engine": engine, "model": "test-model", **(extra or {})}
+        with patch("oas_cli.providers.registry.OpenAIProvider") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.invoke.side_effect = fake_invoke
+            mock_cls.return_value = mock_instance
+            invoke_intelligence("sys", "usr", base)
+
+        return mock_instance.invoke.call_args[1]["config"]
+
+    def test_grok_default_endpoint(self):
+        cfg = self._captured_invoke("grok")
+        assert cfg["endpoint"] == "https://api.x.ai/v1"
+
+    def test_grok_default_api_key_env(self):
+        cfg = self._captured_invoke("grok")
+        assert cfg["api_key_env"] == "XAI_API_KEY"
+
+    def test_grok_default_model_in_defaults_table(self):
+        assert _OPENAI_COMPAT_DEFAULTS["grok"]["model"] == "grok-3-latest"
+
+    def test_spec_model_overrides_grok_default(self):
+        cfg = self._captured_invoke("grok", {"model": "grok-2"})
+        assert cfg["model"] == "grok-2"
+
+    def test_xai_same_defaults_as_grok(self):
+        cfg = self._captured_invoke("xai")
+        assert cfg["endpoint"] == _OPENAI_COMPAT_DEFAULTS["grok"]["endpoint"]
+        assert cfg["api_key_env"] == _OPENAI_COMPAT_DEFAULTS["grok"]["api_key_env"]
+
+    def test_local_has_no_api_key_env(self):
+        cfg = self._captured_invoke("local")
+        assert cfg.get("api_key_env") is None
+
+    def test_local_default_endpoint(self):
+        cfg = self._captured_invoke("local")
+        assert "localhost" in cfg["endpoint"]
+
+    def test_local_endpoint_overridable(self):
+        cfg = self._captured_invoke("local", {"endpoint": "http://localhost:1234/v1"})
+        assert cfg["endpoint"] == "http://localhost:1234/v1"
+
+    def test_cortex_uses_openai_key_env_by_default(self):
+        cfg = self._captured_invoke("cortex")
+        assert cfg["api_key_env"] == "OPENAI_API_KEY"
+
+    def test_cortex_api_key_env_overridable(self):
+        cfg = self._captured_invoke("cortex", {"api_key_env": "CORTEX_API_KEY"})
+        assert cfg["api_key_env"] == "CORTEX_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider — auth header behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProviderAuth:
+    def _make_provider_call(self, *, api_key_env: str | None, env_vars: dict):
+        """Run OpenAIProvider.invoke with a mocked HTTP call and return the request headers."""
+        captured_headers: dict = {}
+
+        def fake_http_post(url, payload, headers):
+            captured_headers.update(headers)
+            return '{"choices": [{"message": {"content": "hi"}}]}'
+
+        with patch.dict("os.environ", env_vars, clear=False):
+            with patch("oas_cli.providers.openai_http._http_post", side_effect=fake_http_post):
+                provider = OpenAIProvider()
+                config: dict = {"model": "gpt-4o", "endpoint": "https://api.openai.com/v1"}
+                if api_key_env is not None:
+                    config["api_key_env"] = api_key_env
+                provider.invoke(system="sys", user="usr", config=config)
+
+        return captured_headers
+
+    def test_auth_header_present_when_key_set(self):
+        headers = self._make_provider_call(
+            api_key_env="OPENAI_API_KEY",
+            env_vars={"OPENAI_API_KEY": "sk-test"},
+        )
+        assert "Authorization" in headers
+        assert headers["Authorization"] == "Bearer sk-test"
+
+    def test_no_auth_header_when_api_key_env_is_none(self):
+        """Local/anonymous endpoints — explicit api_key_env=None skips auth entirely."""
+        captured_headers: dict = {}
+
+        def fake_http_post(url, payload, headers):
+            captured_headers.update(headers)
+            return '{"choices": [{"message": {"content": "hi"}}]}'
+
+        with patch("oas_cli.providers.openai_http._http_post", side_effect=fake_http_post):
+            provider = OpenAIProvider()
+            provider.invoke(
+                system="sys",
+                user="usr",
+                config={
+                    "model": "llama3.2",
+                    "endpoint": "http://localhost:11434/v1",
+                    "api_key_env": None,  # explicit None — local server, no auth
+                },
+            )
+
+        assert "Authorization" not in captured_headers
+
+    def test_error_when_key_env_set_but_missing(self):
+        import os
+
+        os.environ.pop("MISSING_KEY_ENV_XYZ", None)
+        with pytest.raises(ProviderError, match="MISSING_KEY_ENV_XYZ"):
+            provider = OpenAIProvider()
+            provider.invoke(
+                system="s",
+                user="u",
+                config={"model": "gpt-4o", "api_key_env": "MISSING_KEY_ENV_XYZ"},
+            )
+
+
+# ---------------------------------------------------------------------------
+# CustomProvider
+# ---------------------------------------------------------------------------
+
+
+class TestCustomProvider:
+    def test_no_module_falls_back_to_openai_http(self):
+        # The import is local inside invoke(), so patch at the source module.
+        with patch("oas_cli.providers.openai_http.OpenAIProvider") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.invoke.return_value = '{"result": "ok"}'
+            mock_cls.return_value = mock_instance
+
+            provider = CustomProvider()
+            result = provider.invoke(
+                system="s",
+                user="u",
+                config={"engine": "custom", "model": "my-model", "endpoint": "http://x/v1"},
+            )
+
+        assert result == '{"result": "ok"}'
+
+    def test_module_class_is_called(self, tmp_path, monkeypatch):
+        """A user-supplied class in sys.path is instantiated and run."""
+        import sys
+
+        # Write a tiny router class to a temp file on sys.path
+        router_file = tmp_path / "my_router.py"
+        router_file.write_text(
+            "import json\n"
+            "class MyRouter:\n"
+            "    def __init__(self, endpoint, model, config): self.called = True\n"
+            "    def run(self, prompt, **kwargs): return json.dumps({'echo': prompt})\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        provider = CustomProvider()
+        result = provider.invoke(
+            system="hello",
+            user="world",
+            config={"engine": "custom", "model": "m", "module": "my_router.MyRouter"},
+        )
+        data = json.loads(result)
+        assert "echo" in data
+        assert "hello" in data["echo"]
+        assert "world" in data["echo"]
+
+    def test_bad_module_raises_provider_error(self):
+        provider = CustomProvider()
+        with pytest.raises(ProviderError, match="nonexistent_module_xyz"):
+            provider.invoke(
+                system="s",
+                user="u",
+                config={"module": "nonexistent_module_xyz.MyClass"},
+            )
+
+    def test_missing_dot_in_module_path_raises(self):
+        provider = CustomProvider()
+        with pytest.raises(ProviderError, match="module.ClassName"):
+            provider.invoke(system="s", user="u", config={"module": "NoDotsHere"})
+
+    def test_class_not_found_raises(self, tmp_path, monkeypatch):
+        import sys
+
+        mod_file = tmp_path / "empty_mod.py"
+        mod_file.write_text("# nothing here\n")
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        provider = CustomProvider()
+        with pytest.raises(ProviderError, match="GhostClass"):
+            provider.invoke(
+                system="s",
+                user="u",
+                config={"module": "empty_mod.GhostClass"},
+            )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -233,8 +233,8 @@ class TestRunTaskFromSpecOverrides:
     def test_override_system_reaches_invoke(self, monkeypatch):
         captured: dict = {}
 
-        def fake_invoke(prompt: str, config: dict) -> str:
-            captured["prompt"] = prompt
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            captured["prompt"] = f"{system}\n\n{user}"
             return '{"result": "ok"}'
 
         monkeypatch.setattr("oas_cli.runner.invoke_intelligence", fake_invoke)
@@ -252,8 +252,8 @@ class TestRunTaskFromSpecOverrides:
     def test_no_override_uses_spec_prompt(self, monkeypatch):
         captured: dict = {}
 
-        def fake_invoke(prompt: str, config: dict) -> str:
-            captured["prompt"] = prompt
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            captured["prompt"] = f"{system}\n\n{user}"
             return '{"result": "ok"}'
 
         monkeypatch.setattr("oas_cli.runner.invoke_intelligence", fake_invoke)
@@ -292,7 +292,7 @@ class TestResponseFormatText:
     def test_text_mode_returns_raw_string(self, monkeypatch):
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: "This is plain prose output.",
+            lambda s, u, c: "This is plain prose output.",
         )
         result = run_task_from_spec(
             _text_spec(), task_name="prose", input_data={"topic": "cats"}
@@ -303,7 +303,7 @@ class TestResponseFormatText:
         """Raw output that is NOT valid JSON must be returned unchanged in text mode."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: "Not JSON at all { broken",
+            lambda s, u, c: "Not JSON at all { broken",
         )
         result = run_task_from_spec(
             _text_spec(), task_name="prose", input_data={"topic": "x"}
@@ -313,7 +313,7 @@ class TestResponseFormatText:
     def test_text_mode_does_not_parse_fenced_json(self, monkeypatch):
         """Even fenced JSON should be returned as-is in text mode (no fence stripping)."""
         raw = '```json\n{"key": "val"}\n```'
-        monkeypatch.setattr("oas_cli.runner.invoke_intelligence", lambda p, c: raw)
+        monkeypatch.setattr("oas_cli.runner.invoke_intelligence", lambda s, u, c: raw)
         result = run_task_from_spec(
             _text_spec(), task_name="prose", input_data={"topic": "x"}
         )
@@ -323,7 +323,7 @@ class TestResponseFormatText:
         """response_format: json (default) still parses JSON as before."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: '{"result": "ok"}',
+            lambda s, u, c: '{"result": "ok"}',
         )
         result = run_task_from_spec(
             _text_spec("json"), task_name="prose", input_data={"topic": "x"}
@@ -335,7 +335,7 @@ class TestResponseFormatText:
         spec = _spec(global_system="sys", global_user="{{ q }}")
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: '{"result": "fine"}',
+            lambda s, u, c: '{"result": "fine"}',
         )
         result = run_task_from_spec(spec, task_name="mytask", input_data={"q": "hi"})
         assert result["output"] == {"result": "fine"}
@@ -372,7 +372,7 @@ class TestOARunError:
         assert err.task == "missing"
 
     def test_invoke_error_wrapped_in_oa_run_error(self, monkeypatch):
-        def bad_invoke(p, c):
+        def bad_invoke(s, u, c):
             raise RuntimeError("network timeout")
 
         monkeypatch.setattr("oas_cli.runner.invoke_intelligence", bad_invoke)
@@ -423,8 +423,8 @@ class TestDependsOn:
     def test_chain_executes_dependency_first(self, monkeypatch):
         calls: list[str] = []
 
-        def fake_invoke(prompt: str, config: dict) -> str:
-            if "extract" in prompt or calls == []:
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            if "extract" in user or calls == []:
                 calls.append("extract")
                 return '{"facts": "the sky is blue"}'
             calls.append("summarize")
@@ -441,8 +441,8 @@ class TestDependsOn:
         """Facts from extract must appear in summarize's prompt."""
         prompts_seen: list[str] = []
 
-        def fake_invoke(prompt: str, config: dict) -> str:
-            prompts_seen.append(prompt)
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            prompts_seen.append(f"{system}\n\n{user}")
             if len(prompts_seen) == 1:
                 return '{"facts": "the sky is blue"}'
             return '{"summary": "sky"}'
@@ -457,8 +457,8 @@ class TestDependsOn:
         """When both base input and dep output have the same key, dep output wins."""
         prompts_seen: list[str] = []
 
-        def fake_invoke(prompt: str, config: dict) -> str:
-            prompts_seen.append(prompt)
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            prompts_seen.append(f"{system}\n\n{user}")
             if len(prompts_seen) == 1:
                 return '{"facts": "from dep"}'
             return '{"summary": "ok"}'
@@ -473,17 +473,9 @@ class TestDependsOn:
         assert "from caller" not in prompts_seen[1]
 
     def test_chain_result_includes_intermediate(self, monkeypatch):
-        monkeypatch.setattr(
-            "oas_cli.runner.invoke_intelligence",
-            lambda p, c: (
-                '{"facts": "x"}'
-                if "extract" in c.get("model", "") or len(p) < 100
-                else '{"summary": "y"}'
-            ),
-        )
         calls = {"n": 0}
 
-        def fake_invoke(prompt: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict) -> str:
             calls["n"] += 1
             if calls["n"] == 1:
                 return '{"facts": "extracted facts"}'
@@ -499,7 +491,7 @@ class TestDependsOn:
         """Tasks with no depends_on must NOT add a chain key."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: '{"facts": "x"}',
+            lambda s, u, c: '{"facts": "x"}',
         )
         spec = _chain_spec()
         result = run_task_from_spec(spec, task_name="extract", input_data={})
@@ -511,7 +503,7 @@ class TestDependsOn:
         spec["tasks"]["summarize"]["depends_on"] = ["nonexistent"]
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: '{"facts": "x"}',
+            lambda s, u, c: '{"facts": "x"}',
         )
         with pytest.raises(OARunError) as exc_info:
             run_task_from_spec(spec, task_name="summarize", input_data={})
@@ -523,7 +515,7 @@ class TestDependsOn:
         spec["tasks"]["extract"]["depends_on"] = ["summarize"]
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: "{}",
+            lambda s, u, c: "{}",
         )
         with pytest.raises(OARunError) as exc_info:
             run_task_from_spec(spec, task_name="summarize", input_data={})
@@ -533,7 +525,7 @@ class TestDependsOn:
         """If required fields are still missing after merge, fail fast."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: "{}",  # dep returns empty output
+            lambda s, u, c: "{}",  # dep returns empty output
         )
         spec = _chain_spec()
         # extract output missing 'facts', summarize needs nothing required — swap:
@@ -699,7 +691,7 @@ class TestContractEnforcementLive:
     def test_valid_output_passes(self, monkeypatch):
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: '{"summary": "all good", "confidence": "high"}',
+            lambda s, u, c: '{"summary": "all good", "confidence": "high"}',
         )
         spec = self._contract_spec(["summary", "confidence"])
         result = run_task_from_spec(spec, task_name="mytask", input_data={"q": "hi"})
@@ -708,7 +700,7 @@ class TestContractEnforcementLive:
     def test_missing_required_field_raises_contract_violation(self, monkeypatch):
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: '{"summary": "ok"}',  # missing 'confidence'
+            lambda s, u, c: '{"summary": "ok"}',  # missing 'confidence'
         )
         spec = self._contract_spec(["summary", "confidence"])
         with pytest.raises(OARunError) as exc_info:
@@ -723,7 +715,7 @@ class TestContractEnforcementLive:
         """response_format: text must never raise CONTRACT_VIOLATION."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: "plain prose — no fields at all",
+            lambda s, u, c: "plain prose — no fields at all",
         )
         spec = self._contract_spec(["summary"], response_format="text")
         result = run_task_from_spec(spec, task_name="mytask", input_data={"q": "hi"})
@@ -733,7 +725,7 @@ class TestContractEnforcementLive:
         """Top-level contract applies when task has none of its own."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda p, c: '{"summary": "ok"}',  # missing global 'confidence'
+            lambda s, u, c: '{"summary": "ok"}',  # missing global 'confidence'
         )
         spec = {
             "open_agent_spec": "1.3.0",
@@ -765,8 +757,8 @@ class TestContractEnforcementLive:
         """Contract violation on a dependency must halt the chain before the main task runs."""
         calls: list[str] = []
 
-        def fake_invoke(prompt: str, config: dict) -> str:
-            calls.append(prompt)
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            calls.append(f"{system}\n\n{user}")
             return '{"wrong_field": "oops"}'  # missing 'facts'
 
         monkeypatch.setattr("oas_cli.runner.invoke_intelligence", fake_invoke)


### PR DESCRIPTION
## What changed

- Remove the reliance on provider SDKS
- Create a central wrapper that handles provider interactions

## Why

- The SDKs are large to ship with the library & we want to protect OA from breaking changes on an SDK upgrade etc.

## How tested

- All baseline test pass for agent creation and runtime.

- [x] All existing tests pass (`pytest tests/`)
- [x] New tests added (if applicable)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring / CI / tooling

## Breaking changes

<!-- If none, delete this section. Otherwise list what breaks and migration steps. -->

## Checklist

- [x] Code follows project style (`ruff check . && ruff format --check .`)
- [x] Self-review completed
- [x] Version bumped if needed (`pyproject.toml`, templates, docs)
