### PR TITLE
feat: test harness for OA agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ OA deliberately does not prescribe:
 | `oa init aac` | Create `.agents/` with starter specs |
 | `oa validate aac` | Validate all specs in `.agents/` |
 | `oa validate --spec agent.yaml` | Validate one spec |
+| `oa test agent.test.yaml` | Run YAML eval cases (model + assertions on task output); `--quiet` for CI JSON |
 | `oa run --spec agent.yaml --task greet --input '{"name":"Alice"}' --quiet` | Run one task directly from YAML |
 | `oa init --spec agent.yaml --output ./agent` | Generate a Python scaffold |
 | `oa update --spec agent.yaml --output ./agent` | Regenerate an existing scaffold |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -191,6 +191,42 @@ When `oa run --quiet` encounters a failure it emits a machine-readable JSON obje
 
 Verbose mode (`oa run` without `--quiet`) prints the error to the terminal as plain text, unchanged from prior behaviour.
 
+### `oa test` (eval cases)
+
+`oa test` loads a YAML file that points at a spec and lists **cases**. Each case runs one task (with the same `depends_on` resolution as `oa run`), then asserts on the parsed task **`output`** using `expect` rules. Use this for regression checks and CI gates; use `oa validate` for schema-only checks.
+
+```bash
+oa test path/to/agent.test.yaml
+oa test path/to/agent.test.yaml --quiet   # single JSON summary on stdout
+```
+
+**Test file shape**
+
+```yaml
+spec: ./agent.yaml          # relative to this file’s directory
+cases:
+  - name: optional label
+    task: greet             # optional; defaults like `oa run`
+    input: { name: "CI" }
+    expect:
+      output.response: { contains: "hello" }
+      output.items: { min_length: 1, type: array }
+      output.items[0].id: { type: string }
+```
+
+Keys under `expect` must be `output` or start with `output.`; the remainder is a dotted path with optional `[index]` segments (e.g. `output.questions[0]`).
+
+**Rules** (all rules under a path must pass):
+
+| Rule | Meaning |
+|---|---|
+| `min_length` / `max_length` | For strings or lists, `len(value)` bound |
+| `contains` | Substring (default case-insensitive; set `case_sensitive: true` otherwise) |
+| `equals` | Exact equality |
+| `type` | One of `string`, `number`, `boolean`, `object` / `dict`, `array` / `list` |
+
+Omit `expect` or use `{}` for a **smoke** case that only checks the task completes without error.
+
 ---
 
 ## depends_on — linear task chaining

--- a/oas_cli/main.py
+++ b/oas_cli/main.py
@@ -19,6 +19,7 @@ from .core import generate_files as core_generate_files
 from .core import validate_spec_file
 from .exceptions import AgentGenerationError
 from .runner import OARunError, _choose_task, _load_spec, run_task_from_file
+from .spec_test import SpecTestError, run_cases_from_file
 
 app = typer.Typer(help="Open Agent (OA) CLI")
 console = Console()
@@ -229,6 +230,16 @@ oa validate aac
 ```bash
 oa run --spec .agents/example.yaml --task greet --input '{"name": "CI"}' --quiet
 ```
+
+## Eval / regression tests (``oa test``)
+
+Declare cases in a ``*.test.yaml`` next to your spec (see ``docs/REFERENCE.md``), then:
+
+```bash
+oa test .agents/example.test.yaml
+```
+
+Use ``--quiet`` for a single JSON summary line in CI.
 
 ## Review a diff (code reviewer agent)
 
@@ -700,6 +711,90 @@ def run(
             log.error(str(err))
             typer.echo(str(err), err=True)
         raise typer.Exit(1)
+
+
+@app.command()
+def test(
+    test_file: Path = typer.Argument(
+        ...,
+        help="YAML file with `spec:` and `cases:` (e.g. agent.test.yaml)",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Print only a JSON summary to stdout (CI-friendly)",
+    ),
+):
+    """Run eval cases against a spec: real model calls plus assertions on task output.
+
+    The test file references a spec (path relative to the test file). Each case
+    runs ``oa run``-equivalent task execution, then checks ``expect`` rules on
+    ``output.*`` paths (min_length, contains, equals, type, …).
+    """
+    log = setup_logging(verbose)
+    if verbose:
+        log.setLevel(logging.DEBUG)
+    if quiet and not verbose:
+        logging.getLogger("oas").setLevel(logging.WARNING)
+
+    try:
+        results, spec_path = run_cases_from_file(test_file)
+    except SpecTestError as err:
+        typer.echo(str(err), err=True)
+        raise typer.Exit(2) from err
+    except ValueError as err:
+        typer.echo(str(err), err=True)
+        raise typer.Exit(2) from err
+
+    passed_n = sum(1 for r in results if r.passed)
+    failed_n = len(results) - passed_n
+
+    if quiet:
+        payload = {
+            "spec": str(spec_path),
+            "test_file": str(test_file.resolve()),
+            "passed": passed_n,
+            "failed": failed_n,
+            "cases": [
+                {
+                    "name": r.name,
+                    "task": r.task,
+                    "passed": r.passed,
+                    "errors": r.errors,
+                }
+                for r in results
+            ],
+        }
+        typer.echo(json.dumps(payload, indent=2))
+        raise typer.Exit(0 if failed_n == 0 else 1)
+
+    console.print(
+        Panel.fit(
+            f"[bold]Spec[/] {spec_path}\n[bold]Test file[/] {test_file.resolve()}",
+            title="[bold cyan]oa test[/]",
+        )
+    )
+    for r in results:
+        if r.passed:
+            console.print(f"[green]✔[/] [bold]{r.name}[/]  ([dim]{r.task}[/])")
+        else:
+            console.print(f"[red]✘[/] [bold]{r.name}[/]  ([dim]{r.task}[/])")
+            for line in r.errors:
+                console.print(f"    [red]{line}[/]")
+
+    summary = f"{passed_n} passed, {failed_n} failed"
+    if failed_n == 0:
+        console.print(f"\n[green]{summary}[/]")
+        raise typer.Exit(0)
+    console.print(f"\n[red]{summary}[/]")
+    raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/oas_cli/spec_test.py
+++ b/oas_cli/spec_test.py
@@ -1,0 +1,317 @@
+# Copyright (c) Prime Vector Australia, Andrew Whitehouse, Open Agent Stack contributors
+# Licensed under the MIT License. See LICENSE for details.
+
+"""Load YAML eval cases for a spec, run tasks, and assert on structured output."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .core import validate_spec_file
+from .runner import OARunError, run_task_from_file
+
+
+class SpecTestError(Exception):
+    """Invalid test file or configuration."""
+
+
+def load_test_definition(path: Path) -> dict[str, Any]:
+    """Parse a ``*.test.yaml`` (or any YAML) test definition file."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SpecTestError(f"Cannot read test file: {path}") from exc
+    try:
+        data = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        raise SpecTestError(f"Invalid YAML in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SpecTestError("Test file must decode to a YAML mapping at the top level")
+    return data
+
+
+def resolve_spec_path(test_file: Path, spec_ref: Any) -> Path:
+    """Resolve ``spec:`` relative to the test file's directory."""
+    if not isinstance(spec_ref, str) or not spec_ref.strip():
+        raise SpecTestError("Test file must set a non-empty string 'spec:' path")
+    ref = spec_ref.strip()
+    p = Path(ref)
+    if not p.is_absolute():
+        p = (test_file.parent / p).resolve()
+    return p
+
+
+_SEGMENT_RE = re.compile(r"^([^[\]]+)(\[(\d+)\])?$")
+
+
+def _parse_segment(seg: str) -> tuple[str, int | None]:
+    seg = seg.strip()
+    if not seg:
+        raise SpecTestError(f"Invalid empty path segment in {seg!r}")
+    m = _SEGMENT_RE.match(seg)
+    if not m:
+        raise SpecTestError(f"Invalid path segment: {seg!r}")
+    name, bracket, idx_s = m.group(1), m.group(2), m.group(3)
+    if not name:
+        raise SpecTestError(f"Invalid path segment: {seg!r}")
+    idx = int(idx_s) if bracket else None
+    return name, idx
+
+
+def navigate_value(root: Any, dotted_path: str) -> Any:
+    """Follow a path like ``questions[0].title`` starting from *root* (a dict or list)."""
+    path = dotted_path.strip()
+    if not path:
+        return root
+    current: Any = root
+    for seg in path.split("."):
+        key, idx = _parse_segment(seg)
+        if isinstance(current, dict):
+            if key not in current:
+                raise KeyError(key)
+            current = current[key]
+        else:
+            raise TypeError(f"cannot index non-mapping with {key!r}")
+        if idx is not None:
+            if not isinstance(current, (list, tuple)):
+                raise TypeError(
+                    f"segment [{idx}] requires a list, got {type(current).__name__}"
+                )
+            if idx < 0 or idx >= len(current):
+                raise IndexError(
+                    f"index {idx} out of range for path (len={len(current)})"
+                )
+            current = current[idx]
+    return current
+
+
+def _output_path(expect_key: str) -> str:
+    """Strip optional ``output.`` prefix; remainder is navigated from task output dict."""
+    key = expect_key.strip()
+    if key.startswith("output."):
+        return key[len("output.") :]
+    if key == "output":
+        return ""
+    raise SpecTestError(
+        f"Expectation key must start with 'output.' or be 'output', got {expect_key!r}"
+    )
+
+
+def _check_rule(
+    value: Any,
+    rule_name: str,
+    rule_val: Any,
+    *,
+    case_sensitive: bool,
+) -> str | None:
+    """Return an error message if the rule fails, else None."""
+    if rule_name == "min_length":
+        if not isinstance(rule_val, int) or rule_val < 0:
+            return f"min_length must be a non-negative int, got {rule_val!r}"
+        try:
+            ln = len(value)  # type: ignore[arg-type]
+        except TypeError:
+            return f"min_length: value is not sized (got {type(value).__name__})"
+        if ln < rule_val:
+            return f"min_length: expected len >= {rule_val}, got {ln}"
+        return None
+
+    if rule_name == "max_length":
+        if not isinstance(rule_val, int) or rule_val < 0:
+            return f"max_length must be a non-negative int, got {rule_val!r}"
+        try:
+            ln = len(value)  # type: ignore[arg-type]
+        except TypeError:
+            return f"max_length: value is not sized (got {type(value).__name__})"
+        if ln > rule_val:
+            return f"max_length: expected len <= {rule_val}, got {ln}"
+        return None
+
+    if rule_name == "contains":
+        if not isinstance(rule_val, str):
+            return f"contains: expected string needle, got {type(rule_val).__name__}"
+        hay = value if isinstance(value, str) else json.dumps(value, default=str)
+        if not case_sensitive:
+            ok = rule_val.lower() in hay.lower()
+        else:
+            ok = rule_val in hay
+        if not ok:
+            return f"contains: expected substring {rule_val!r} not found in value"
+        return None
+
+    if rule_name == "equals":
+        if value != rule_val:
+            return f"equals: expected {rule_val!r}, got {value!r}"
+        return None
+
+    if rule_name == "type":
+        if rule_val == "string":
+            if not isinstance(value, str):
+                return f"type: expected string, got {type(value).__name__}"
+        elif rule_val == "number":
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                return f"type: expected number, got {type(value).__name__}"
+        elif rule_val == "boolean":
+            if not isinstance(value, bool):
+                return f"type: expected boolean, got {type(value).__name__}"
+        elif rule_val in ("object", "dict"):
+            if not isinstance(value, dict):
+                return f"type: expected object, got {type(value).__name__}"
+        elif rule_val in ("array", "list"):
+            if not isinstance(value, list):
+                return f"type: expected array, got {type(value).__name__}"
+        else:
+            return f"type: unsupported type label {rule_val!r}"
+        return None
+
+    if rule_name == "case_sensitive":
+        return None  # handled as meta-flag
+
+    return f"unknown expectation rule {rule_name!r}"
+
+
+def check_expectations(
+    output_obj: Any,
+    expect_block: dict[str, Any],
+) -> list[str]:
+    """Evaluate all paths in *expect_block* against *output_obj* (task output). Return errors."""
+    errors: list[str] = []
+    if not isinstance(expect_block, dict):
+        return [f"expect must be a mapping, got {type(expect_block).__name__}"]
+
+    for path_key, rules in expect_block.items():
+        if not isinstance(path_key, str):
+            errors.append(f"expect keys must be strings, got {path_key!r}")
+            continue
+        try:
+            subpath = _output_path(path_key)
+        except SpecTestError as exc:
+            errors.append(str(exc))
+            continue
+
+        if not isinstance(rules, dict):
+            errors.append(
+                f"{path_key}: rules must be a mapping, got {type(rules).__name__}"
+            )
+            continue
+
+        case_sensitive = bool(rules.get("case_sensitive", False))
+
+        try:
+            if subpath == "":
+                at = output_obj
+            else:
+                if not isinstance(output_obj, dict):
+                    errors.append(
+                        f"{path_key}: output is not an object, cannot navigate path"
+                    )
+                    continue
+                at = navigate_value(output_obj, subpath)
+        except KeyError as exc:
+            errors.append(f"{path_key}: missing key {exc!s}")
+            continue
+        except (TypeError, IndexError) as exc:
+            errors.append(f"{path_key}: {exc}")
+            continue
+
+        for rule_name, rule_val in rules.items():
+            msg = _check_rule(at, rule_name, rule_val, case_sensitive=case_sensitive)
+            if msg:
+                errors.append(f"{path_key}: {msg}")
+
+    return errors
+
+
+@dataclass
+class CaseResult:
+    name: str
+    task: str
+    passed: bool
+    errors: list[str] = field(default_factory=list)
+    envelope: dict[str, Any] | None = None
+
+
+def run_cases_from_file(test_file: Path) -> tuple[list[CaseResult], Path]:
+    """Validate spec, run each case, apply expectations. Returns results and spec path."""
+    definition = load_test_definition(test_file)
+    spec_path = resolve_spec_path(test_file, definition.get("spec"))
+    validate_spec_file(spec_path)
+
+    cases_raw = definition.get("cases")
+    if not isinstance(cases_raw, list):
+        raise SpecTestError("'cases' must be a list")
+
+    results: list[CaseResult] = []
+    for i, case in enumerate(cases_raw):
+        if not isinstance(case, dict):
+            raise SpecTestError(f"cases[{i}] must be a mapping")
+        name = case.get("name")
+        if name is None:
+            name = f"case_{i}"
+        elif not isinstance(name, str):
+            raise SpecTestError(f"cases[{i}].name must be a string")
+
+        task = case.get("task")
+        if task is not None and not isinstance(task, str):
+            raise SpecTestError(f"cases[{i}].task must be a string")
+
+        inp = case.get("input")
+        if inp is None:
+            input_data: dict[str, Any] = {}
+        elif isinstance(inp, dict):
+            input_data = dict(inp)
+        else:
+            raise SpecTestError(f"cases[{i}].input must be a mapping or omitted")
+
+        expect = case.get("expect")
+        if expect is None:
+            expect = {}
+        if not isinstance(expect, dict):
+            raise SpecTestError(f"cases[{i}].expect must be a mapping or omitted")
+
+        try:
+            envelope = run_task_from_file(
+                spec_path,
+                task_name=task,
+                input_data=input_data,
+            )
+        except OARunError as exc:
+            results.append(
+                CaseResult(
+                    name=name,
+                    task=task or "(default)",
+                    passed=False,
+                    errors=[f"run error [{exc.code}]: {exc}"],
+                )
+            )
+            continue
+        except Exception as exc:  # pragma: no cover — defensive
+            results.append(
+                CaseResult(
+                    name=name,
+                    task=task or "(default)",
+                    passed=False,
+                    errors=[f"unexpected error: {exc}"],
+                )
+            )
+            continue
+
+        out = envelope.get("output")
+        errs = check_expectations(out, expect) if expect else []
+        results.append(
+            CaseResult(
+                name=name,
+                task=str(envelope.get("task", task or "")),
+                passed=len(errs) == 0,
+                errors=errs,
+                envelope=envelope,
+            )
+        )
+
+    return results, spec_path

--- a/tests/test_spec_test.py
+++ b/tests/test_spec_test.py
@@ -113,7 +113,7 @@ def test_run_cases_from_file_with_mock(tmp_path: Path):
     spec.write_text(_MINIMAL_RUNNABLE_SPEC)
     testf = tmp_path / "agent.test.yaml"
     testf.write_text(
-        f"""\
+        """\
 spec: agent.yaml
 cases:
   - name: smoke

--- a/tests/test_spec_test.py
+++ b/tests/test_spec_test.py
@@ -1,0 +1,195 @@
+"""Tests for oas_cli.spec_test path navigation and expectations."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from oas_cli.main import app
+from oas_cli.spec_test import (
+    SpecTestError,
+    check_expectations,
+    load_test_definition,
+    navigate_value,
+    resolve_spec_path,
+    run_cases_from_file,
+)
+
+runner = CliRunner()
+
+
+def test_navigate_value_nested_dict_and_index():
+    data = {"questions": ["first Q", "second"], "meta": {"n": 1}}
+    assert navigate_value(data, "questions[0]") == "first Q"
+    assert navigate_value(data, "meta.n") == 1
+
+
+def test_navigate_value_empty_path_returns_root():
+    assert navigate_value({"a": 1}, "") == {"a": 1}
+
+
+def test_check_expectations_min_length_and_contains():
+    out = {"questions": ["What are the main climate risks?", "How do we adapt?"]}
+    errs = check_expectations(
+        out,
+        {
+            "output.questions": {"min_length": 2},
+            "output.questions[0]": {"contains": "climate"},
+        },
+    )
+    assert errs == []
+
+
+def test_check_expectations_failure_messages():
+    out = {"questions": ["only one"]}
+    errs = check_expectations(
+        out,
+        {"output.questions": {"min_length": 2}},
+    )
+    assert len(errs) == 1
+    assert "min_length" in errs[0]
+
+
+def test_check_expectations_bad_path_key():
+    errs = check_expectations({}, {"foo.bar": {"equals": 1}})
+    assert any("output." in e for e in errs)
+
+
+def test_resolve_spec_path_relative(tmp_path: Path):
+    tf = tmp_path / "dir" / "t.test.yaml"
+    tf.parent.mkdir(parents=True)
+    tf.write_text("x: 1")
+    spec = resolve_spec_path(tf, "./agent.yaml")
+    assert spec == (tmp_path / "dir" / "agent.yaml").resolve()
+
+
+def test_load_test_definition_roundtrip(tmp_path: Path):
+    p = tmp_path / "x.test.yaml"
+    p.write_text("spec: a.yaml\ncases: []\n")
+    d = load_test_definition(p)
+    assert d["spec"] == "a.yaml"
+
+
+_MINIMAL_RUNNABLE_SPEC = """\
+open_agent_spec: "1.3.0"
+
+agent:
+  name: test-agent
+  description: test agent
+  role: chat
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o
+
+tasks:
+  greet:
+    description: say hello
+    input:
+      type: object
+      properties:
+        name: { type: string }
+      required: [name]
+    output:
+      type: object
+      properties:
+        response: { type: string }
+      required: [response]
+    prompts:
+      system: "You are a greeter."
+      user: "Hello {{ name }}"
+
+prompts:
+  system: "Global system fallback."
+  user: "{{ name }}"
+"""
+
+
+def test_run_cases_from_file_with_mock(tmp_path: Path):
+    spec = tmp_path / "agent.yaml"
+    spec.write_text(_MINIMAL_RUNNABLE_SPEC)
+    testf = tmp_path / "agent.test.yaml"
+    testf.write_text(
+        f"""\
+spec: agent.yaml
+cases:
+  - name: smoke
+    task: greet
+    input:
+      name: "Bob"
+    expect:
+      output.response:
+        contains: "Bob"
+        min_length: 1
+"""
+    )
+
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        return json.dumps({"response": "Hello Bob from mock"})
+
+    with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
+        results, resolved = run_cases_from_file(testf)
+    assert resolved == spec.resolve()
+    assert len(results) == 1
+    assert results[0].passed
+    assert results[0].errors == []
+
+
+def test_run_cases_expect_failure(tmp_path: Path):
+    spec = tmp_path / "agent.yaml"
+    spec.write_text(_MINIMAL_RUNNABLE_SPEC)
+    testf = tmp_path / "agent.test.yaml"
+    testf.write_text(
+        """\
+spec: agent.yaml
+cases:
+  - task: greet
+    input: { name: "x" }
+    expect:
+      output.response:
+        contains: "ZZZNOTFOUND"
+"""
+    )
+
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        return json.dumps({"response": "Hello x"})
+
+    with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
+        results, _ = run_cases_from_file(testf)
+    assert not results[0].passed
+    assert any("contains" in e for e in results[0].errors)
+
+
+def test_run_cases_invalid_test_file_raises():
+    with pytest.raises(SpecTestError):
+        run_cases_from_file(Path("/nonexistent/nope.test.yaml"))
+
+
+def test_oa_test_cli_quiet_json(tmp_path: Path):
+    spec = tmp_path / "agent.yaml"
+    spec.write_text(_MINIMAL_RUNNABLE_SPEC)
+    testf = tmp_path / "agent.test.yaml"
+    testf.write_text(
+        """\
+spec: agent.yaml
+cases:
+  - task: greet
+    input: { name: "Bob" }
+    expect:
+      output.response: { contains: "Bob" }
+"""
+    )
+
+    def fake_invoke(system: str, user: str, config: dict) -> str:
+        return json.dumps({"response": "Hi Bob"})
+
+    with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
+        result = runner.invoke(app, ["test", str(testf), "--quiet"])
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.stdout)
+    assert summary["passed"] == 1
+    assert summary["failed"] == 0
+    assert summary["cases"][0]["passed"] is True


### PR DESCRIPTION
## What changed

- Allow testing of agent specifications to directly see how inputs and outputs will behave with real usage
- Allow users to productionise their agents fully rather than just relying on the static checking of the spec

## Why

- Currently we only support spec validations

## How tested

- Exploratory

- [x] All existing tests pass (`pytest tests/`)
- [x] New tests added (if applicable)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring / CI / tooling

## Breaking changes

<!-- If none, delete this section. Otherwise list what breaks and migration steps. -->

## Checklist

- [x] Code follows project style (`ruff check . && ruff format --check .`)
- [x] Self-review completed
- [x] Version bumped if needed (`pyproject.toml`, templates, docs)
