### PR TITLE
feat: add tool use with native, MCP, and custom providers

### DIFF
--- a/examples/file-reader/a-file.txt
+++ b/examples/file-reader/a-file.txt
@@ -1,0 +1,15 @@
+Was the Hospitaller considered an angel in Kingdom of Heaven?
+
+Yes, the Hospitaller (played by David Thewlis) in Kingdom of Heaven is heavily implied to be an angel or a divine messenger. Writer William Monahan confirmed in the DVD commentary that the character is meant to represent an angel. 
+Reddit
+Reddit
+ +1
+Key details supporting this interpretation include:
+Supernatural Elements: The character appears and disappears mysteriously in the desert without a horse.
+"Angelness" in Action: He tells Balian he has "not heard" that Balian is outside of God's grace, implying direct communion with God.
+Guiding Role: He acts as a spiritual guide for Balian, offering wisdom, appearing to know more than a mortal, and emphasizing mercy and duty over the fanaticism of the Templars.
+The Director's Cut: The Director's Cut makes the implication more explicit compared to the theatrical release. 
+Reddit
+Reddit
+ +4
+While some viewers might interpret him simply as a very pious, observant knight, the filmmakers intended him to be an angelic figure ensuring Balian follows his destiny.

--- a/examples/file-reader/file-reader.yaml
+++ b/examples/file-reader/file-reader.yaml
@@ -1,0 +1,55 @@
+open_agent_spec: "1.3.0"
+
+agent:
+  name: file-reader
+  description: >
+    Reads a file from disk and answers questions about its content.
+    Demonstrates the native file.read tool — no SDKs, no frameworks.
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+
+# Declare the tools available to this agent.
+tools:
+  read_file:
+    type: native
+    native: file.read
+    description: "Read the contents of a text file from the local filesystem."
+
+tasks:
+  summarise:
+    description: >
+      Read a file and return a concise summary of its content.
+    tools:
+      - read_file
+    prompts:
+      system: >
+        You are a helpful assistant. When asked to summarise a file, use the
+        read_file tool to fetch its contents first, then write a clear, concise
+        summary. Respond with valid JSON matching the output schema.
+      user: "Please summarise the file at path: {path}"
+    input:
+      type: object
+      properties:
+        path:
+          type: string
+          description: Path to the file to read.
+      required:
+        - path
+    output:
+      type: object
+      properties:
+        summary:
+          type: string
+          description: A short summary of the file contents.
+        key_points:
+          type: array
+          items:
+            type: string
+          description: Bullet-point key takeaways.
+      required:
+        - summary
+        - key_points

--- a/examples/file-reader/notes.txt
+++ b/examples/file-reader/notes.txt
@@ -1,0 +1,15 @@
+Project: Acme Platform
+Status: In progress
+
+Q1 priorities:
+- Finish authentication module
+- Add rate limiting to the API
+- Write integration tests for the payments service
+
+Blockers:
+- Waiting on design approval for the dashboard
+- Redis cluster not provisioned yet
+
+Notes from team standup (2026-03-19):
+Alice is picking up the Redis ticket.
+Bob to review the auth PR by end of day.

--- a/examples/file-reader/run.sh
+++ b/examples/file-reader/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run the file-reader example.
+# Requires OPENAI_API_KEY to be set.
+#
+# Usage:
+#   ./run.sh                         # summarise the bundled notes.txt
+#   ./run.sh /path/to/your/file.txt  # summarise any file you like
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPEC="$SCRIPT_DIR/file-reader.yaml"
+FILE="${1:-$SCRIPT_DIR/notes.txt}"
+
+echo "==> Spec : $SPEC"
+echo "==> File : $FILE"
+echo ""
+
+oa run "$SPEC" --task summarise --input "{\"path\": \"$FILE\"}"

--- a/examples/mcp-local/agent.yaml
+++ b/examples/mcp-local/agent.yaml
@@ -1,0 +1,59 @@
+open_agent_spec: "1.3.0"
+
+agent:
+  name: text-analyser
+  description: >
+    Analyses text using tools provided by a local MCP server.
+    A self-contained demo — run server.py first, then oa run this spec.
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+
+tools:
+  text_tools:
+    type: mcp
+    endpoint: "http://localhost:3000"
+    description: "Local text analysis tools (word_count, char_count, reverse_text)"
+
+tasks:
+  analyse:
+    description: >
+      Analyse a piece of text using the available MCP tools and return statistics.
+    tools:
+      - text_tools
+    prompts:
+      system: >
+        You are a text analysis assistant. Use the available tools to measure
+        the text provided by the user. Call each relevant tool and include the
+        results in your response. Respond with valid JSON matching the output schema.
+      user: "Analyse this text: {text}"
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to analyse.
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        word_count:
+          type: integer
+          description: Number of words in the text.
+        char_count:
+          type: integer
+          description: Number of characters in the text.
+        reversed:
+          type: string
+          description: The text reversed.
+        summary:
+          type: string
+          description: A one-sentence summary of the analysis.
+      required:
+        - word_count
+        - char_count
+        - summary

--- a/examples/mcp-local/run.sh
+++ b/examples/mcp-local/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Two-terminal demo of OAS + MCP.
+#
+# Terminal 1 — start the MCP server:
+#   python3 examples/mcp-local/server.py
+#
+# Terminal 2 — run the agent (this script):
+#   ./examples/mcp-local/run.sh
+#   ./examples/mcp-local/run.sh "The quick brown fox jumps over the lazy dog"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPEC="$SCRIPT_DIR/agent.yaml"
+TEXT="${1:-Hello world, this is a test of the MCP tool integration.}"
+
+echo "==> Spec : $SPEC"
+echo "==> Text : $TEXT"
+echo ""
+
+oa run "$SPEC" --task analyse --input "{\"text\": \"$TEXT\"}"

--- a/examples/mcp-local/server.py
+++ b/examples/mcp-local/server.py
@@ -1,0 +1,148 @@
+"""Minimal local MCP server — pure Python stdlib, no dependencies.
+
+Exposes three tools:
+  word_count   Count words in a string.
+  char_count   Count characters in a string.
+  reverse_text Reverse a string.
+
+Speaks JSON-RPC 2.0 over HTTP on port 3000 (or $MCP_PORT).
+Run it with:  python3 server.py
+"""
+
+import datetime
+import json
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = int(os.environ.get("MCP_PORT", 3000))
+
+TOOLS = [
+    {
+        "name": "word_count",
+        "description": "Count the number of words in a text string.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to count words in.",
+                }
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "char_count",
+        "description": "Count the number of characters (including spaces) in a text string.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to count characters in.",
+                }
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "reverse_text",
+        "description": "Reverse the characters in a text string.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to reverse.",
+                }
+            },
+            "required": ["text"],
+        },
+    },
+]
+
+
+def _handle_tool_call(name: str, arguments: dict) -> dict:
+    """Execute a tool and return an MCP content block result."""
+    text = arguments.get("text", "")
+
+    if name == "word_count":
+        count = len(text.split())
+        result = f"{count} word{'s' if count != 1 else ''}"
+
+    elif name == "char_count":
+        count = len(text)
+        result = f"{count} character{'s' if count != 1 else ''}"
+
+    elif name == "reverse_text":
+        result = text[::-1]
+
+    else:
+        return {
+            "content": [{"type": "text", "text": f"Unknown tool: {name}"}],
+            "isError": True,
+        }
+
+    return {"content": [{"type": "text", "text": result}]}
+
+
+class MCPHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+
+        try:
+            request = json.loads(raw)
+        except json.JSONDecodeError:
+            self._send(400, {"error": "invalid JSON"})
+            return
+
+        method = request.get("method", "")
+        request_id = request.get("id")
+
+        if method == "tools/list":
+            self._jsonrpc(request_id, {"tools": TOOLS})
+
+        elif method == "tools/call":
+            params = request.get("params", {})
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments", {})
+            result = _handle_tool_call(tool_name, arguments)
+            self._jsonrpc(request_id, result)
+
+        else:
+            self._jsonrpc(
+                request_id,
+                error={"code": -32601, "message": f"Method not found: {method}"},
+            )
+
+    def _jsonrpc(self, request_id, result=None, error=None):
+        response = {"jsonrpc": "2.0", "id": request_id}
+        if error:
+            response["error"] = error
+        else:
+            response["result"] = result
+        self._send(200, response)
+
+    def _send(self, status: int, data: dict):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        ts = datetime.datetime.now().strftime("%H:%M:%S")
+        print(f"[{ts}] MCP  {fmt % args}")
+
+
+if __name__ == "__main__":
+    server = HTTPServer(("localhost", PORT), MCPHandler)
+    print(f"Local MCP server running on http://localhost:{PORT}")
+    print(f"Tools: {', '.join(t['name'] for t in TOOLS)}")
+    print("Press Ctrl+C to stop.\n")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")

--- a/examples/mcp-search/README.md
+++ b/examples/mcp-search/README.md
@@ -1,0 +1,92 @@
+# MCP Search Example
+
+Demonstrates connecting an OAS agent to any MCP (Model Context Protocol) server
+for live web search — with **no MCP SDK**, no heavy dependencies, just raw HTTP.
+
+## How it works
+
+```
+oa run → MCPToolProvider → tools/list  → discovers available tools
+                         → tools/call  → executes search, returns result
+                         → model sees result → generates final answer
+```
+
+OAS speaks JSON-RPC 2.0 over HTTP directly to your MCP server, the same way
+it calls OpenAI and Anthropic — raw `urllib.request`, nothing else needed.
+
+## Quick start
+
+**1. Start an MCP server.**
+
+Any MCP-compatible server works. Examples:
+
+```bash
+# Brave Search MCP server (Node)
+npx @modelcontextprotocol/server-brave-search
+
+# Or any other MCP server — filesystem, GitHub, Slack, Postgres, etc.
+```
+
+**2. Set your credentials.**
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export BRAVE_MCP_TOKEN="your-brave-api-key"   # if your server needs auth
+```
+
+**3. Update the endpoint in the spec** (if your server runs on a different port):
+
+```yaml
+tools:
+  brave_search:
+    type: mcp
+    endpoint: "http://localhost:3000"   # ← change this
+```
+
+**4. Run it.**
+
+```bash
+oa run --spec examples/mcp-search/mcp-search.yaml \
+       --input '{"topic": "latest advances in open source LLMs 2026"}'
+```
+
+## Connecting other MCP servers
+
+Just change `endpoint` — the rest is automatic. OAS calls `tools/list` to
+discover whatever tools your server exposes and presents them to the model.
+
+```yaml
+tools:
+  github:
+    type: mcp
+    endpoint: "http://localhost:3001"
+    headers:
+      Authorization: "Bearer ${GITHUB_TOKEN}"
+
+  filesystem:
+    type: mcp
+    endpoint: "http://localhost:3002"
+
+tasks:
+  my_task:
+    tools: [github, filesystem]   # mix and match freely
+```
+
+## What OAS sends to your MCP server
+
+**Tool discovery** (once, cached):
+```json
+{"jsonrpc": "2.0", "method": "tools/list", "id": 1}
+```
+
+**Tool execution** (per model request):
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {"name": "brave_web_search", "arguments": {"query": "..."}},
+  "id": 2
+}
+```
+
+Standard JSON-RPC 2.0 — works with any compliant server.

--- a/examples/mcp-search/mcp-search.yaml
+++ b/examples/mcp-search/mcp-search.yaml
@@ -1,0 +1,70 @@
+open_agent_spec: "1.3.0"
+
+agent:
+  name: mcp-researcher
+  description: >
+    A researcher agent that uses an MCP server for web search.
+    Demonstrates connecting OAS to any MCP-compatible tool server
+    with no SDK dependency — just HTTP.
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+
+# ── Tool declarations ──────────────────────────────────────────────────────
+#
+# Point 'endpoint' at any running MCP server.  OAS calls tools/list on
+# startup to discover what tools it exposes, then tools/call at runtime.
+# No MCP library needed — it's plain JSON-RPC 2.0 over HTTP.
+#
+# Header values can reference environment variables with ${VAR_NAME}.
+
+tools:
+  brave_search:
+    type: mcp
+    endpoint: "http://localhost:3000"        # replace with your MCP server URL
+    description: "Search the web using Brave Search via MCP"
+    headers:
+      Authorization: "Bearer ${BRAVE_MCP_TOKEN}"   # set in your environment
+    timeout: 30
+
+tasks:
+  research:
+    description: >
+      Research a topic using web search and return a structured summary.
+    tools:
+      - brave_search
+    prompts:
+      system: >
+        You are a research assistant. Use the available search tools to find
+        accurate, up-to-date information. Always search before answering.
+        Respond with valid JSON matching the output schema.
+      user: "Research the following topic and summarise your findings: {topic}"
+    input:
+      type: object
+      properties:
+        topic:
+          type: string
+          description: The topic to research.
+      required:
+        - topic
+    output:
+      type: object
+      properties:
+        summary:
+          type: string
+          description: A concise summary of the findings.
+        sources:
+          type: array
+          items:
+            type: string
+          description: URLs or references used.
+        confidence:
+          type: string
+          enum: [high, medium, low]
+          description: Confidence level in the findings.
+      required:
+        - summary
+        - confidence

--- a/oas_cli/providers/anthropic_http.py
+++ b/oas_cli/providers/anthropic_http.py
@@ -9,6 +9,7 @@ import urllib.request
 from typing import Any
 
 from .base import IntelligenceProvider, ProviderError
+from oas_cli.tool_providers.base import InvokeResult, ToolCall
 
 _DEFAULT_ENDPOINT = "https://api.anthropic.com/v1/messages"
 # TODO: model names go stale — consider requiring specs to always declare
@@ -74,3 +75,86 @@ class AnthropicProvider(IntelligenceProvider):
             return data["content"][0]["text"]
         except (KeyError, IndexError, TypeError) as exc:
             raise ProviderError(f"Unexpected Anthropic response shape: {data}") from exc
+
+    def supports_tools(self) -> bool:
+        return True
+
+    def invoke_with_tools(
+        self,
+        *,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        config: dict,
+    ) -> InvokeResult:
+        api_key_env = config.get("api_key_env", "ANTHROPIC_API_KEY")
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            raise ProviderError(
+                f"Anthropic API key not set — export {api_key_env} or set "
+                "intelligence.config.api_key_env in your spec."
+            )
+
+        endpoint = config.get("endpoint", _DEFAULT_ENDPOINT)
+        if not endpoint.endswith("/messages"):
+            endpoint = endpoint.rstrip("/") + "/messages"
+
+        model = config.get("model", _DEFAULT_MODEL)
+        temperature = float(config.get("temperature", 0.7))
+        max_tokens = int(config.get("max_tokens", 1000))
+        timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
+
+        # Convert OpenAI-format tool defs to Anthropic format.
+        anthropic_tools = [
+            {
+                "name": t["function"]["name"],
+                "description": t["function"].get("description", ""),
+                "input_schema": t["function"].get("parameters", {"type": "object", "properties": {}}),
+            }
+            for t in tools
+        ]
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if system:
+            payload["system"] = system
+        if anthropic_tools:
+            payload["tools"] = anthropic_tools
+
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+
+        body = json.dumps(payload).encode()
+        req = urllib.request.Request(endpoint, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            raise ProviderError(f"Anthropic HTTP {exc.code}: {detail}") from exc
+        except Exception as exc:
+            raise ProviderError(f"Anthropic request failed: {exc}") from exc
+
+        stop_reason = data.get("stop_reason")
+        if stop_reason == "tool_use":
+            tool_calls = [
+                ToolCall(
+                    id=block["id"],
+                    name=block["name"],
+                    arguments=block.get("input", {}),
+                )
+                for block in data.get("content", [])
+                if block.get("type") == "tool_use"
+            ]
+            return InvokeResult(is_final=False, tool_calls=tool_calls)
+
+        # Extract text from the final response.
+        text_blocks = [b["text"] for b in data.get("content", []) if b.get("type") == "text"]
+        return InvokeResult(is_final=True, text="\n".join(text_blocks))

--- a/oas_cli/providers/anthropic_http.py
+++ b/oas_cli/providers/anthropic_http.py
@@ -8,8 +8,9 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-from .base import IntelligenceProvider, ProviderError
 from oas_cli.tool_providers.base import InvokeResult, ToolCall
+
+from .base import IntelligenceProvider, ProviderError
 
 _DEFAULT_ENDPOINT = "https://api.anthropic.com/v1/messages"
 # TODO: model names go stale — consider requiring specs to always declare
@@ -109,7 +110,9 @@ class AnthropicProvider(IntelligenceProvider):
             {
                 "name": t["function"]["name"],
                 "description": t["function"].get("description", ""),
-                "input_schema": t["function"].get("parameters", {"type": "object", "properties": {}}),
+                "input_schema": t["function"].get(
+                    "parameters", {"type": "object", "properties": {}}
+                ),
             }
             for t in tools
         ]
@@ -132,7 +135,9 @@ class AnthropicProvider(IntelligenceProvider):
         }
 
         body = json.dumps(payload).encode()
-        req = urllib.request.Request(endpoint, data=body, headers=headers, method="POST")
+        req = urllib.request.Request(
+            endpoint, data=body, headers=headers, method="POST"
+        )
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
@@ -156,5 +161,7 @@ class AnthropicProvider(IntelligenceProvider):
             return InvokeResult(is_final=False, tool_calls=tool_calls)
 
         # Extract text from the final response.
-        text_blocks = [b["text"] for b in data.get("content", []) if b.get("type") == "text"]
+        text_blocks = [
+            b["text"] for b in data.get("content", []) if b.get("type") == "text"
+        ]
         return InvokeResult(is_final=True, text="\n".join(text_blocks))

--- a/oas_cli/providers/base.py
+++ b/oas_cli/providers/base.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from oas_cli.tool_providers.base import InvokeResult, ToolDefinition
 
 
 class ProviderError(RuntimeError):
@@ -35,3 +39,36 @@ class IntelligenceProvider(ABC):
         Raises:
             ProviderError: On any HTTP or response-shape failure.
         """
+
+    def supports_tools(self) -> bool:
+        """Return True if this provider natively supports multi-turn tool calling."""
+        return False
+
+    def invoke_with_tools(
+        self,
+        *,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        config: dict,
+    ) -> "InvokeResult":
+        """Single-turn invocation supporting tool use (function calling).
+
+        Args:
+            system:   System prompt.
+            messages: Full conversation history in OpenAI message format.
+            tools:    OpenAI-format tool definitions (``[{"type": "function", …}]``).
+            config:   Provider config dict.
+
+        Returns:
+            ``InvokeResult`` — either ``is_final=True`` with ``text``, or
+            ``is_final=False`` with ``tool_calls`` to execute.
+
+        Raises:
+            ProviderError: On transport or response-shape failure.
+            NotImplementedError: If the provider does not override this method.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support tool use. "
+            "Override invoke_with_tools() or use a provider that supports it."
+        )

--- a/oas_cli/providers/base.py
+++ b/oas_cli/providers/base.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from oas_cli.tool_providers.base import InvokeResult, ToolDefinition
+    from oas_cli.tool_providers.base import InvokeResult
 
 
 class ProviderError(RuntimeError):
@@ -51,7 +51,7 @@ class IntelligenceProvider(ABC):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         config: dict,
-    ) -> "InvokeResult":
+    ) -> InvokeResult:
         """Single-turn invocation supporting tool use (function calling).
 
         Args:

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -9,6 +9,7 @@ import urllib.request
 from typing import Any
 
 from .base import IntelligenceProvider, ProviderError
+from oas_cli.tool_providers.base import InvokeResult, ToolCall
 
 # Default to the Chat Completions API; set intelligence.endpoint in your spec
 # to switch to the Responses API (https://api.openai.com/v1/responses) or a
@@ -64,6 +65,70 @@ class OpenAIProvider(IntelligenceProvider):
 
         return _http_post(endpoint, payload, headers=extra_headers, timeout=timeout)
 
+    def supports_tools(self) -> bool:
+        return True
+
+    def invoke_with_tools(
+        self,
+        *,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        config: dict,
+    ) -> InvokeResult:
+        api_key_env: str | None = config.get("api_key_env", "OPENAI_API_KEY")
+        api_key: str | None = os.environ.get(api_key_env) if api_key_env else None
+        if api_key_env and not api_key:
+            raise ProviderError(
+                f"API key not set — export {api_key_env} or set "
+                "intelligence.config.api_key_env in your spec."
+            )
+
+        # Tool use is only supported on the Chat Completions endpoint.
+        endpoint = config.get("endpoint", _DEFAULT_ENDPOINT)
+        if not endpoint.endswith("/chat/completions"):
+            endpoint = endpoint.rstrip("/").removesuffix("/responses") + "/chat/completions"
+
+        model = config.get("model", _DEFAULT_MODEL)
+        temperature = float(config.get("temperature", 0.7))
+        max_tokens = int(config.get("max_tokens", 1000))
+        timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
+
+        all_messages = [{"role": "system", "content": system}] + messages
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": all_messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        if tools:
+            payload["tools"] = tools
+            payload["tool_choice"] = "auto"
+
+        extra_headers: dict[str, str] = {}
+        if api_key:
+            extra_headers["Authorization"] = f"Bearer {api_key}"
+
+        data = _http_post_raw(endpoint, payload, headers=extra_headers, timeout=timeout)
+
+        message = data.get("choices", [{}])[0].get("message", {})
+        finish_reason = data.get("choices", [{}])[0].get("finish_reason", "stop")
+
+        if finish_reason == "tool_calls":
+            raw_calls = message.get("tool_calls") or []
+            tool_calls = [
+                ToolCall(
+                    id=tc["id"],
+                    name=tc["function"]["name"],
+                    arguments=json.loads(tc["function"].get("arguments", "{}")),
+                )
+                for tc in raw_calls
+            ]
+            return InvokeResult(is_final=False, tool_calls=tool_calls)
+
+        text = message.get("content") or ""
+        return InvokeResult(is_final=True, text=text)
+
 
 def _build_chat_completions_payload(
     system: str, user: str, model: str, temperature: float, max_tokens: int
@@ -92,9 +157,10 @@ def _build_responses_payload(
     }
 
 
-def _http_post(
+def _http_post_raw(
     url: str, payload: dict, headers: dict, timeout: int = _DEFAULT_TIMEOUT
-) -> str:
+) -> dict[str, Any]:
+    """POST to *url* and return the parsed JSON response as a dict."""
     all_headers = {
         "Content-Type": "application/json",
         **headers,
@@ -103,13 +169,18 @@ def _http_post(
     req = urllib.request.Request(url, data=body, headers=all_headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode())
+            return json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")
         raise ProviderError(f"OpenAI HTTP {exc.code}: {detail}") from exc
     except Exception as exc:
         raise ProviderError(f"OpenAI request failed: {exc}") from exc
 
+
+def _http_post(
+    url: str, payload: dict, headers: dict, timeout: int = _DEFAULT_TIMEOUT
+) -> str:
+    data = _http_post_raw(url, payload, headers=headers, timeout=timeout)
     return _extract_text(data, url)
 
 

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -8,8 +8,9 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-from .base import IntelligenceProvider, ProviderError
 from oas_cli.tool_providers.base import InvokeResult, ToolCall
+
+from .base import IntelligenceProvider, ProviderError
 
 # Default to the Chat Completions API; set intelligence.endpoint in your spec
 # to switch to the Responses API (https://api.openai.com/v1/responses) or a
@@ -87,7 +88,9 @@ class OpenAIProvider(IntelligenceProvider):
         # Tool use is only supported on the Chat Completions endpoint.
         endpoint = config.get("endpoint", _DEFAULT_ENDPOINT)
         if not endpoint.endswith("/chat/completions"):
-            endpoint = endpoint.rstrip("/").removesuffix("/responses") + "/chat/completions"
+            endpoint = (
+                endpoint.rstrip("/").removesuffix("/responses") + "/chat/completions"
+            )
 
         model = config.get("model", _DEFAULT_MODEL)
         temperature = float(config.get("temperature", 0.7))

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -18,8 +18,6 @@ import yaml
 from .providers import ProviderError, invoke_intelligence
 from .providers.registry import get_provider
 from .tool_providers import (
-    ToolCall,
-    ToolDefinition,
     ToolError,
     dispatch_tool_call,
     resolve_task_tools,
@@ -374,8 +372,7 @@ def _invoke_with_tools(
     if not provider.supports_tools():
         # Inject tool descriptions into the system prompt for text-only providers.
         tool_descriptions = "\n".join(
-            f"- {defn.name}: {defn.description}"
-            for _, defn in tools
+            f"- {defn.name}: {defn.description}" for _, defn in tools
         )
         augmented_system = (
             f"{system}\n\nYou have access to the following tools:\n{tool_descriptions}"
@@ -405,18 +402,23 @@ def _invoke_with_tools(
             return ""
 
         # Append the assistant's tool-call request to the history.
-        messages.append({
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
-                }
-                for tc in result.tool_calls
-            ],
-        })
+        messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": json.dumps(tc.arguments),
+                        },
+                    }
+                    for tc in result.tool_calls
+                ],
+            }
+        )
 
         # Execute every tool call and append results.
         for tc in result.tool_calls:
@@ -425,11 +427,13 @@ def _invoke_with_tools(
             except ToolError as exc:
                 tool_result = f"[tool error] {exc}"
                 logger.warning("[tools] Tool '%s' raised: %s", tc.name, exc)
-            messages.append({
-                "role": "tool",
-                "tool_call_id": tc.id,
-                "content": tool_result,
-            })
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": tool_result,
+                }
+            )
 
     raise OARunError(
         f"Tool-call loop for task '{task_name}' exceeded {_MAX_TOOL_ITERATIONS} iterations.",
@@ -474,7 +478,9 @@ def _run_single_task(
     try:
         tools = resolve_task_tools(spec_data, task_name)
         if tools:
-            raw_output = _invoke_with_tools(system, user, tools, intelligence_config, task_name)
+            raw_output = _invoke_with_tools(
+                system, user, tools, intelligence_config, task_name
+            )
         else:
             raw_output = invoke_intelligence(system, user, intelligence_config)
     except (ProviderError, ToolError) as exc:

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -16,6 +16,15 @@ from typing import Any
 import yaml
 
 from .providers import ProviderError, invoke_intelligence
+from .providers.registry import get_provider
+from .tool_providers import (
+    ToolCall,
+    ToolDefinition,
+    ToolError,
+    dispatch_tool_call,
+    resolve_task_tools,
+)
+from .tool_providers.base import InvokeResult
 
 logger = logging.getLogger(__name__)
 
@@ -171,10 +180,12 @@ def _resolve_prompts(
 
     user = user_template
     for key, value in input_data.items():
-        placeholder = "{{ " + key + " }}"
-        user = user.replace(placeholder, str(value))
-        placeholder_input = "{{ input." + key + " }}"
-        user = user.replace(placeholder_input, str(value))
+        str_val = str(value)
+        # Single-brace Python style: {key}
+        user = user.replace(f"{{{key}}}", str_val)
+        # Double-brace Jinja style: {{ key }} and {{ input.key }}
+        user = user.replace("{{ " + key + " }}", str_val)
+        user = user.replace("{{ input." + key + " }}", str_val)
 
     return system, user
 
@@ -336,6 +347,98 @@ def _resolve_contract(
     return _merge_contracts(global_contract, task_contract)
 
 
+_MAX_TOOL_ITERATIONS = 10
+
+
+def _invoke_with_tools(
+    system: str,
+    user: str,
+    tools: list,
+    intelligence_config: dict[str, Any],
+    task_name: str,
+) -> str:
+    """Multi-turn tool-call loop.
+
+    Builds the initial message list, asks the provider to invoke (potentially
+    returning tool calls), executes those calls via the registered tool providers,
+    feeds results back, and repeats until the model returns a final answer or the
+    iteration cap is hit.
+
+    Falls back to a single ``invoke_intelligence`` call when the selected provider
+    does not support tool use natively (e.g. Codex adapter).
+    """
+    provider = get_provider(intelligence_config)
+
+    tool_defs = [defn.to_openai_schema() for _, defn in tools]
+
+    if not provider.supports_tools():
+        # Inject tool descriptions into the system prompt for text-only providers.
+        tool_descriptions = "\n".join(
+            f"- {defn.name}: {defn.description}"
+            for _, defn in tools
+        )
+        augmented_system = (
+            f"{system}\n\nYou have access to the following tools:\n{tool_descriptions}"
+        )
+        return invoke_intelligence(augmented_system, user, intelligence_config)
+
+    messages: list[dict[str, Any]] = [{"role": "user", "content": user}]
+
+    for iteration in range(_MAX_TOOL_ITERATIONS):
+        result: InvokeResult = provider.invoke_with_tools(
+            system=system,
+            messages=messages,
+            tools=tool_defs,
+            config=intelligence_config,
+        )
+
+        if result.is_final:
+            return result.text
+
+        if not result.tool_calls:
+            logger.warning(
+                "[tools] Provider returned is_final=False with no tool_calls on task '%s' "
+                "(iteration %d). Treating as final with empty response.",
+                task_name,
+                iteration,
+            )
+            return ""
+
+        # Append the assistant's tool-call request to the history.
+        messages.append({
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
+                }
+                for tc in result.tool_calls
+            ],
+        })
+
+        # Execute every tool call and append results.
+        for tc in result.tool_calls:
+            try:
+                tool_result = dispatch_tool_call(tc.name, tc.arguments, tools)
+            except ToolError as exc:
+                tool_result = f"[tool error] {exc}"
+                logger.warning("[tools] Tool '%s' raised: %s", tc.name, exc)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": tool_result,
+            })
+
+    raise OARunError(
+        f"Tool-call loop for task '{task_name}' exceeded {_MAX_TOOL_ITERATIONS} iterations.",
+        code="RUN_ERROR",
+        stage="run",
+        task=task_name,
+    )
+
+
 def _run_single_task(
     spec_data: dict[str, Any],
     task_name: str,
@@ -369,8 +472,12 @@ def _run_single_task(
     intelligence_config = _build_intelligence_config(spec_data)
 
     try:
-        raw_output = invoke_intelligence(system, user, intelligence_config)
-    except ProviderError as exc:
+        tools = resolve_task_tools(spec_data, task_name)
+        if tools:
+            raw_output = _invoke_with_tools(system, user, tools, intelligence_config, task_name)
+        else:
+            raw_output = invoke_intelligence(system, user, intelligence_config)
+    except (ProviderError, ToolError) as exc:
         raise OARunError(
             str(exc),
             code="PROVIDER_ERROR",

--- a/oas_cli/schemas/oas-schema.json
+++ b/oas_cli/schemas/oas-schema.json
@@ -1,418 +1,515 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://openagents.org/schemas/oas-schema.json",
-    "title": "Open Agent Spec",
-    "description": "Schema for Open Agent Spec YAML files",
-    "type": "object",
-    "required": [
-      "open_agent_spec",
-      "agent",
-      "intelligence",
-      "tasks"
-    ],
-    "properties": {
-      "open_agent_spec": {
-        "type": "string",
-        "pattern": "^(1\\.(0\\.[4-9]|[1-9]\\.[0-9]+)|[2-9]\\.[0-9]+\\.[0-9]+)$",
-        "description": "Version of the Open Agent Spec (minimum 1.0.4)"
-      },
-      "agent": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string",
-            "description": "Free text description of what the agent does"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "analyst",
-              "reviewer",
-              "chat",
-              "retriever",
-              "planner",
-              "executor"
-            ],
-            "description": "Optional role type for the agent"
-          }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://openagents.org/schemas/oas-schema.json",
+  "title": "Open Agent Spec",
+  "description": "Schema for Open Agent Spec YAML files",
+  "type": "object",
+  "required": [
+    "open_agent_spec",
+    "agent",
+    "intelligence",
+    "tasks"
+  ],
+  "properties": {
+    "open_agent_spec": {
+      "type": "string",
+      "pattern": "^(1\\.(0\\.[4-9]|[1-9]\\.[0-9]+)|[2-9]\\.[0-9]+\\.[0-9]+)$",
+      "description": "Version of the Open Agent Spec (minimum 1.0.4)"
+    },
+    "agent": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
         },
-        "required": [
-          "name",
-          "description"
-        ]
+        "description": {
+          "type": "string",
+          "description": "Free text description of what the agent does"
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "analyst",
+            "reviewer",
+            "chat",
+            "retriever",
+            "planner",
+            "executor"
+          ],
+          "description": "Optional role type for the agent"
+        }
       },
-      "intelligence": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "llm"
-            ],
-            "description": "Type of intelligence (currently only LLM supported)"
-          },
-          "engine": {
-            "type": "string",
-            "enum": [
-              "openai",
-              "anthropic",
-              "grok",
-              "xai",
-              "cortex",
-              "codex",
-              "local",
-              "custom"
-            ],
-            "description": "LLM engine provider (e.g., openai, anthropic, grok/xai, cortex, codex, local, custom)"
-          },
-          "model": {
-            "type": "string",
-            "description": "Model name/identifier"
-          },
-          "endpoint": {
-            "type": "string",
-            "pattern": "^(https?://)[^\\s]+$",
-            "description": "API endpoint URL for the LLM service (must be HTTP/HTTPS)"
-          },
-          "config": {
-            "type": "object",
-            "properties": {
-              "temperature": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 2,
-                "description": "Sampling temperature (0-2)"
-              },
-              "max_tokens": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Maximum number of tokens to generate"
-              },
-              "top_p": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1,
-                "description": "Nucleus sampling parameter (0-1)"
-              },
-              "frequency_penalty": {
-                "type": "number",
-                "minimum": -2,
-                "maximum": 2,
-                "description": "Frequency penalty (-2 to 2)"
-              },
-              "presence_penalty": {
-                "type": "number",
-                "minimum": -2,
-                "maximum": 2,
-                "description": "Presence penalty (-2 to 2)"
-              },
-              "enable_layer3": {
-                "type": "boolean",
-                "description": "Enable Layer 3 intelligence capabilities (Cortex-specific)"
-              },
-              "enable_onnx": {
-                "type": "boolean",
-                "description": "Enable ONNX runtime optimization (Cortex-specific)"
-              },
-              "openai_api_key": {
-                "type": "string",
-                "description": "OpenAI API key for Cortex integration"
-              },
-              "claude_api_key": {
-                "type": "string",
-                "description": "Claude API key for Cortex integration"
-              }
+      "required": [
+        "name",
+        "description"
+      ]
+    },
+    "intelligence": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "llm"
+          ],
+          "description": "Type of intelligence (currently only LLM supported)"
+        },
+        "engine": {
+          "type": "string",
+          "enum": [
+            "openai",
+            "anthropic",
+            "grok",
+            "xai",
+            "cortex",
+            "codex",
+            "local",
+            "custom"
+          ],
+          "description": "LLM engine provider (e.g., openai, anthropic, grok/xai, cortex, codex, local, custom)"
+        },
+        "model": {
+          "type": "string",
+          "description": "Model name/identifier"
+        },
+        "endpoint": {
+          "type": "string",
+          "pattern": "^(https?://)[^\\s]+$",
+          "description": "API endpoint URL for the LLM service (must be HTTP/HTTPS)"
+        },
+        "config": {
+          "type": "object",
+          "properties": {
+            "temperature": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 2,
+              "description": "Sampling temperature (0-2)"
             },
-            "description": "Configuration parameters for the LLM"
-          }
-        },
-        "required": [
-          "type",
-          "engine",
-          "model"
-        ]
+            "max_tokens": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum number of tokens to generate"
+            },
+            "top_p": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Nucleus sampling parameter (0-1)"
+            },
+            "frequency_penalty": {
+              "type": "number",
+              "minimum": -2,
+              "maximum": 2,
+              "description": "Frequency penalty (-2 to 2)"
+            },
+            "presence_penalty": {
+              "type": "number",
+              "minimum": -2,
+              "maximum": 2,
+              "description": "Presence penalty (-2 to 2)"
+            },
+            "enable_layer3": {
+              "type": "boolean",
+              "description": "Enable Layer 3 intelligence capabilities (Cortex-specific)"
+            },
+            "enable_onnx": {
+              "type": "boolean",
+              "description": "Enable ONNX runtime optimization (Cortex-specific)"
+            },
+            "openai_api_key": {
+              "type": "string",
+              "description": "OpenAI API key for Cortex integration"
+            },
+            "claude_api_key": {
+              "type": "string",
+              "description": "Claude API key for Cortex integration"
+            }
+          },
+          "description": "Configuration parameters for the LLM"
+        }
       },
-      "tasks": {
-        "type": "object",
-        "patternProperties": {
-          "^[a-zA-Z0-9_-]+$": {
-            "type": "object",
-            "properties": {
-              "description": {
-                "type": "string",
-                "description": "Description of what this task does"
-              },
-              "timeout": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Timeout in seconds for this task"
-              },
-              "input": {
-                "type": "object",
+      "required": [
+        "type",
+        "engine",
+        "model"
+      ]
+    },
+    "tasks": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Description of what this task does"
+            },
+            "timeout": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout in seconds for this task"
+            },
+            "input": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "object"
+                  ],
+                  "default": "object",
+                  "description": "Type of input (currently only object supported)"
+                },
                 "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": ["object"],
-                    "default": "object",
-                    "description": "Type of input (currently only object supported)"
-                  },
-                  "properties": {
-                    "type": "object",
-                    "patternProperties": {
-                      "^[a-zA-Z_][a-zA-Z0-9_]*$": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "enum": ["string", "number", "integer", "boolean", "array", "object"],
-                            "description": "JSON Schema type for this property"
-                          },
-                          "description": {
-                            "type": "string",
-                            "description": "Description of this input property"
-                          },
-                          "default": {
-                            "description": "Default value for this property"
-                          },
-                          "enum": {
-                            "type": "array",
-                            "description": "Allowed values for this property"
-                          },
-                          "minimum": {
-                            "type": "number",
-                            "description": "Minimum value for numeric properties"
-                          },
-                          "maximum": {
-                            "type": "number",
-                            "description": "Maximum value for numeric properties"
-                          },
-                          "minLength": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "description": "Minimum length for string properties"
-                          },
-                          "maxLength": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "description": "Maximum length for string properties"
-                          },
-                          "pattern": {
-                            "type": "string",
-                            "description": "Regex pattern for string validation"
-                          },
-                          "items": {
-                            "type": "object",
-                            "description": "Schema for array items"
-                          },
-                          "properties": {
-                            "type": "object",
-                            "description": "Properties for object type"
-                          }
+                  "type": "object",
+                  "patternProperties": {
+                    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string",
+                            "number",
+                            "integer",
+                            "boolean",
+                            "array",
+                            "object"
+                          ],
+                          "description": "JSON Schema type for this property"
                         },
-                        "required": ["type"]
-                      }
-                    },
-                    "additionalProperties": false,
-                    "description": "Input properties schema"
-                  },
-                  "required": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "List of required input properties"
-                  }
-                },
-                "description": "Input schema for this task"
-              },
-              "output": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": ["object"],
-                    "default": "object",
-                    "description": "Type of output (currently only object supported)"
-                  },
-                  "properties": {
-                    "type": "object",
-                    "patternProperties": {
-                      "^[a-zA-Z_][a-zA-Z0-9_]*$": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "enum": ["string", "number", "integer", "boolean", "array", "object"],
-                            "description": "JSON Schema type for this property"
-                          },
-                          "description": {
-                            "type": "string",
-                            "description": "Description of this output property"
-                          },
-                          "default": {
-                            "description": "Default value for this property"
-                          },
-                          "enum": {
-                            "type": "array",
-                            "description": "Allowed values for this property"
-                          },
-                          "minimum": {
-                            "type": "number",
-                            "description": "Minimum value for numeric properties"
-                          },
-                          "maximum": {
-                            "type": "number",
-                            "description": "Maximum value for numeric properties"
-                          },
-                          "minLength": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "description": "Minimum length for string properties"
-                          },
-                          "maxLength": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "description": "Maximum length for string properties"
-                          },
-                          "pattern": {
-                            "type": "string",
-                            "description": "Regex pattern for string validation"
-                          },
-                          "items": {
-                            "type": "object",
-                            "description": "Schema for array items"
-                          },
-                          "properties": {
-                            "type": "object",
-                            "description": "Properties for object type"
-                          }
+                        "description": {
+                          "type": "string",
+                          "description": "Description of this input property"
                         },
-                        "required": ["type"]
-                      }
-                    },
-                    "additionalProperties": false,
-                    "description": "Output properties schema"
+                        "default": {
+                          "description": "Default value for this property"
+                        },
+                        "enum": {
+                          "type": "array",
+                          "description": "Allowed values for this property"
+                        },
+                        "minimum": {
+                          "type": "number",
+                          "description": "Minimum value for numeric properties"
+                        },
+                        "maximum": {
+                          "type": "number",
+                          "description": "Maximum value for numeric properties"
+                        },
+                        "minLength": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Minimum length for string properties"
+                        },
+                        "maxLength": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Maximum length for string properties"
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "Regex pattern for string validation"
+                        },
+                        "items": {
+                          "type": "object",
+                          "description": "Schema for array items"
+                        },
+                        "properties": {
+                          "type": "object",
+                          "description": "Properties for object type"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
                   },
-                  "required": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "List of required output properties"
-                  }
+                  "additionalProperties": false,
+                  "description": "Input properties schema"
                 },
-                "description": "Output schema for this task"
+                "required": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of required input properties"
+                }
               },
-              "prompts": {
-                "type": "object",
+              "description": "Input schema for this task"
+            },
+            "output": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "object"
+                  ],
+                  "default": "object",
+                  "description": "Type of output (currently only object supported)"
+                },
                 "properties": {
-                  "system": {
-                    "type": "string",
-                    "description": "System prompt for this task (overrides global prompts.system)"
+                  "type": "object",
+                  "patternProperties": {
+                    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "string",
+                            "number",
+                            "integer",
+                            "boolean",
+                            "array",
+                            "object"
+                          ],
+                          "description": "JSON Schema type for this property"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Description of this output property"
+                        },
+                        "default": {
+                          "description": "Default value for this property"
+                        },
+                        "enum": {
+                          "type": "array",
+                          "description": "Allowed values for this property"
+                        },
+                        "minimum": {
+                          "type": "number",
+                          "description": "Minimum value for numeric properties"
+                        },
+                        "maximum": {
+                          "type": "number",
+                          "description": "Maximum value for numeric properties"
+                        },
+                        "minLength": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Minimum length for string properties"
+                        },
+                        "maxLength": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Maximum length for string properties"
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "Regex pattern for string validation"
+                        },
+                        "items": {
+                          "type": "object",
+                          "description": "Schema for array items"
+                        },
+                        "properties": {
+                          "type": "object",
+                          "description": "Properties for object type"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
                   },
-                  "user": {
-                    "type": "string",
-                    "description": "User prompt template for this task (overrides global prompts.user)"
-                  }
+                  "additionalProperties": false,
+                  "description": "Output properties schema"
                 },
-                "description": "Per-task prompts. Takes priority over the global prompts section."
+                "required": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of required output properties"
+                }
               },
-              "response_format": {
-                "type": "string",
-                "enum": ["json", "text"],
-                "default": "json",
-                "description": "Output format. 'json' (default): runner parses model output as JSON. 'text': raw model output is returned as-is; output schema validation is skipped."
-              },
-              "depends_on": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "List of task names that must run before this task. Their outputs are merged into this task's input (later entries win on key collision). Linear chains only — no branching or conditions."
-              },
-              "behavioural_contract": {
-                "type": "object",
-                "description": "Per-task behavioural contract. Merged with the top-level behavioural_contract (arrays are unioned, scalars use per-task-wins). Install behavioural-contracts to enable runtime enforcement."
-              }
+              "description": "Output schema for this task"
             },
-            "required": [
-              "description",
-              "output"
-            ]
-          }
-        },
-        "description": "Tasks that this agent can perform"
-      },
-      "prompts": {
-        "type": "object",
-        "properties": {
-          "system": {
-            "type": "string",
-            "description": "Global fallback system prompt used when a task has no per-task prompts"
-          },
-          "user": {
-            "type": "string",
-            "description": "Global fallback user prompt template"
-          }
-        },
-        "description": "Global prompt fallbacks. Per-task prompts (tasks.<name>.prompts) take priority."
-      },
-      "logging": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Whether to enable DACP logging"
-          },
-          "level": {
-            "type": "string",
-            "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-            "default": "INFO",
-            "description": "Logging level"
-          },
-          "format_style": {
-            "type": "string",
-            "enum": ["emoji", "detailed", "simple"],
-            "default": "emoji",
-            "description": "Logging format style"
-          },
-          "include_timestamp": {
-            "type": "boolean",
-            "default": true,
-            "description": "Include timestamps in logs"
-          },
-          "log_file": {
-            "type": "string",
-            "description": "Optional: log to file (auto-creates directories)"
-          },
-          "env_overrides": {
-            "type": "object",
-            "properties": {
-              "level": {
-                "type": "string",
-                "description": "Environment variable that overrides level"
+            "prompts": {
+              "type": "object",
+              "properties": {
+                "system": {
+                  "type": "string",
+                  "description": "System prompt for this task (overrides global prompts.system)"
+                },
+                "user": {
+                  "type": "string",
+                  "description": "User prompt template for this task (overrides global prompts.user)"
+                }
               },
-              "format_style": {
-                "type": "string",
-                "description": "Environment variable that overrides format_style"
-              },
-              "log_file": {
-                "type": "string",
-                "description": "Environment variable that overrides log_file"
-              }
+              "description": "Per-task prompts. Takes priority over the global prompts section."
             },
-            "description": "Environment variable overrides for runtime configuration"
-          }
+            "response_format": {
+              "type": "string",
+              "enum": [
+                "json",
+                "text"
+              ],
+              "default": "json",
+              "description": "Output format. 'json' (default): runner parses model output as JSON. 'text': raw model output is returned as-is; output schema validation is skipped."
+            },
+            "depends_on": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of task names that must run before this task. Their outputs are merged into this task's input (later entries win on key collision). Linear chains only \u2014 no branching or conditions."
+            },
+            "behavioural_contract": {
+              "type": "object",
+              "description": "Per-task behavioural contract. Merged with the top-level behavioural_contract (arrays are unioned, scalars use per-task-wins). Install behavioural-contracts to enable runtime enforcement."
+            },
+            "tools": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Names of tools from the top-level tools: block that this task is allowed to use."
+            }
+          },
+          "required": [
+            "description",
+            "output"
+          ]
+        }
+      },
+      "description": "Tasks that this agent can perform"
+    },
+    "prompts": {
+      "type": "object",
+      "properties": {
+        "system": {
+          "type": "string",
+          "description": "Global fallback system prompt used when a task has no per-task prompts"
         },
-        "description": "DACP logging configuration"
+        "user": {
+          "type": "string",
+          "description": "Global fallback user prompt template"
+        }
       },
-      "behavioural_contract": {
-        "type": "object"
+      "description": "Global prompt fallbacks. Per-task prompts (tasks.<name>.prompts) take priority."
+    },
+    "logging": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to enable DACP logging"
+        },
+        "level": {
+          "type": "string",
+          "enum": [
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL"
+          ],
+          "default": "INFO",
+          "description": "Logging level"
+        },
+        "format_style": {
+          "type": "string",
+          "enum": [
+            "emoji",
+            "detailed",
+            "simple"
+          ],
+          "default": "emoji",
+          "description": "Logging format style"
+        },
+        "include_timestamp": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include timestamps in logs"
+        },
+        "log_file": {
+          "type": "string",
+          "description": "Optional: log to file (auto-creates directories)"
+        },
+        "env_overrides": {
+          "type": "object",
+          "properties": {
+            "level": {
+              "type": "string",
+              "description": "Environment variable that overrides level"
+            },
+            "format_style": {
+              "type": "string",
+              "description": "Environment variable that overrides format_style"
+            },
+            "log_file": {
+              "type": "string",
+              "description": "Environment variable that overrides log_file"
+            }
+          },
+          "description": "Environment variable overrides for runtime configuration"
+        }
       },
-      "interface": {
-        "type": "object"
-      }
+      "description": "DACP logging configuration"
+    },
+    "behavioural_contract": {
+      "type": "object"
+    },
+    "interface": {
+      "type": "object"
+    },
+    "tools": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "native",
+                "mcp",
+                "custom"
+              ],
+              "description": "Tool backend type. 'native' uses built-in OAS tools. 'mcp' connects to any MCP server (JSON-RPC 2.0 over HTTP). 'custom' loads a user-defined Python class."
+            },
+            "native": {
+              "type": "string",
+              "description": "Native tool ID (e.g. file.read, file.write, http.get, http.post, env.read). Required when type is 'native'."
+            },
+            "module": {
+              "type": "string",
+              "description": "Python dotted path to a class implementing ToolProvider. Required when type is 'custom'."
+            },
+            "description": {
+              "type": "string",
+              "description": "Human-readable description of what this tool does (used in model prompts)."
+            },
+            "parameters": {
+              "type": "object",
+              "description": "JSON Schema for tool arguments. Required for custom tools without a describe() method."
+            },
+            "endpoint": {
+              "type": "string",
+              "description": "HTTP endpoint of the MCP server. Required when type is 'mcp'."
+            },
+            "headers": {
+              "type": "object",
+              "description": "Optional HTTP headers sent with every MCP request. Values may use ${ENV_VAR} substitution."
+            },
+            "timeout": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Request timeout in seconds (default 30)."
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "description": "A single tool declaration."
+        }
+      },
+      "description": "Tool declarations available to tasks. Tasks reference tools by name in their tools: list."
     }
   }
+}

--- a/oas_cli/tool_providers/__init__.py
+++ b/oas_cli/tool_providers/__init__.py
@@ -12,7 +12,12 @@ from .base import (
 from .custom import CustomToolProvider
 from .mcp import MCPToolProvider
 from .native import NativeToolProvider, available_native_tools
-from .registry import all_tool_definitions, dispatch_tool_call, get_tool_provider, resolve_task_tools
+from .registry import (
+    all_tool_definitions,
+    dispatch_tool_call,
+    get_tool_provider,
+    resolve_task_tools,
+)
 
 __all__ = [
     "InvokeResult",

--- a/oas_cli/tool_providers/__init__.py
+++ b/oas_cli/tool_providers/__init__.py
@@ -1,0 +1,33 @@
+"""OAS tool provider package."""
+
+from .base import (
+    InvokeResult,
+    ToolCall,
+    ToolDefinition,
+    ToolError,
+    ToolNotFoundError,
+    ToolProvider,
+    ToolTypeNotSupportedError,
+)
+from .custom import CustomToolProvider
+from .mcp import MCPToolProvider
+from .native import NativeToolProvider, available_native_tools
+from .registry import all_tool_definitions, dispatch_tool_call, get_tool_provider, resolve_task_tools
+
+__all__ = [
+    "InvokeResult",
+    "ToolCall",
+    "ToolDefinition",
+    "ToolError",
+    "ToolNotFoundError",
+    "ToolProvider",
+    "ToolTypeNotSupportedError",
+    "CustomToolProvider",
+    "MCPToolProvider",
+    "NativeToolProvider",
+    "available_native_tools",
+    "all_tool_definitions",
+    "dispatch_tool_call",
+    "get_tool_provider",
+    "resolve_task_tools",
+]

--- a/oas_cli/tool_providers/base.py
+++ b/oas_cli/tool_providers/base.py
@@ -29,7 +29,9 @@ class ToolDefinition:
 
     name: str
     description: str
-    parameters: dict[str, Any] = field(default_factory=lambda: {"type": "object", "properties": {}})
+    parameters: dict[str, Any] = field(
+        default_factory=lambda: {"type": "object", "properties": {}}
+    )
 
     def to_openai_schema(self) -> dict[str, Any]:
         """Serialise to the OpenAI function-calling format."""

--- a/oas_cli/tool_providers/base.py
+++ b/oas_cli/tool_providers/base.py
@@ -1,0 +1,90 @@
+"""Base class and types for OAS tool providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ToolError(RuntimeError):
+    """Raised when a tool call fails."""
+
+
+class ToolNotFoundError(ToolError):
+    """Raised when a named tool is not registered."""
+
+
+class ToolTypeNotSupportedError(ToolError):
+    """Raised when the tool type is not recognised."""
+
+
+@dataclass
+class ToolDefinition:
+    """OpenAI-compatible function definition sent to the model.
+
+    The ``parameters`` dict follows JSON Schema — the model receives it verbatim
+    so it knows how to call the tool.
+    """
+
+    name: str
+    description: str
+    parameters: dict[str, Any] = field(default_factory=lambda: {"type": "object", "properties": {}})
+
+    def to_openai_schema(self) -> dict[str, Any]:
+        """Serialise to the OpenAI function-calling format."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+    def to_anthropic_schema(self) -> dict[str, Any]:
+        """Serialise to the Anthropic tool format."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.parameters,
+        }
+
+
+@dataclass
+class ToolCall:
+    """A single tool invocation requested by the model."""
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass
+class InvokeResult:
+    """Return value from a provider's invoke_with_tools call.
+
+    Either ``is_final`` is True and ``text`` carries the answer, or
+    ``tool_calls`` is non-empty and the caller should execute them and continue.
+    """
+
+    is_final: bool
+    text: str = ""
+    tool_calls: list[ToolCall] = field(default_factory=list)
+
+
+class ToolProvider(ABC):
+    """Interface every tool backend must implement."""
+
+    @abstractmethod
+    def describe(self) -> list[ToolDefinition]:
+        """Return the tool definitions for this provider (sent to the model)."""
+
+    @abstractmethod
+    def call(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        """Execute *tool_name* with *arguments* and return a string result.
+
+        Raises:
+            ToolNotFoundError: If the tool name is not handled by this provider.
+            ToolError: On execution failure.
+        """

--- a/oas_cli/tool_providers/custom.py
+++ b/oas_cli/tool_providers/custom.py
@@ -1,0 +1,93 @@
+"""Custom tool provider — dynamically loads a user-defined Python class.
+
+Spec example
+------------
+tools:
+  my_scorer:
+    type: custom
+    module: "my_package.tools.Scorer"
+    description: "Score text quality (0-100)"
+    parameters:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to score.
+      required: [text]
+
+The class at ``my_package.tools.Scorer`` must implement::
+
+    class Scorer:
+        def describe(self) -> list[dict]:
+            ...  # list of OpenAI-compatible function schemas
+
+        def call(self, tool_name: str, arguments: dict) -> str:
+            ...  # execute the tool, return a string
+
+If ``describe()`` is absent the provider synthesises a single-tool definition
+from the ``description`` and ``parameters`` fields in the spec.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from .base import ToolDefinition, ToolError, ToolNotFoundError, ToolProvider
+
+
+class CustomToolProvider(ToolProvider):
+    """Wraps a dynamically-loaded user class as a ToolProvider."""
+
+    def __init__(self, tool_name: str, tool_config: dict[str, Any]) -> None:
+        self._tool_name = tool_name
+        self._config = tool_config
+        module_path: str = tool_config.get("module", "")
+        if not module_path:
+            raise ToolError(
+                f"Custom tool '{tool_name}' must specify a 'module' (e.g. 'my_pkg.MyTool')."
+            )
+
+        try:
+            mod_name, cls_name = module_path.rsplit(".", 1)
+            module = importlib.import_module(mod_name)
+            cls = getattr(module, cls_name)
+            self._instance = cls()
+        except (ImportError, AttributeError, ValueError) as exc:
+            raise ToolError(
+                f"Custom tool '{tool_name}': could not load '{module_path}': {exc}"
+            ) from exc
+
+    def describe(self) -> list[ToolDefinition]:
+        if hasattr(self._instance, "describe"):
+            raw = self._instance.describe()
+            return [
+                ToolDefinition(
+                    name=d["name"],
+                    description=d.get("description", ""),
+                    parameters=d.get("parameters", {"type": "object", "properties": {}}),
+                )
+                for d in raw
+            ]
+        # Synthesise from spec fields
+        return [
+            ToolDefinition(
+                name=self._tool_name.replace(".", "_").replace("-", "_"),
+                description=self._config.get("description", ""),
+                parameters=self._config.get(
+                    "parameters", {"type": "object", "properties": {}}
+                ),
+            )
+        ]
+
+    def call(self, tool_name: str, arguments: dict) -> str:
+        if not hasattr(self._instance, "call"):
+            raise ToolError(
+                f"Custom tool class for '{self._tool_name}' has no 'call' method."
+            )
+        result = self._instance.call(tool_name, arguments)
+        if not isinstance(result, str):
+            raise ToolError(
+                f"Custom tool '{tool_name}' must return a string; got {type(result).__name__}."
+            )
+        return result

--- a/oas_cli/tool_providers/custom.py
+++ b/oas_cli/tool_providers/custom.py
@@ -18,11 +18,9 @@ tools:
 The class at ``my_package.tools.Scorer`` must implement::
 
     class Scorer:
-        def describe(self) -> list[dict]:
-            ...  # list of OpenAI-compatible function schemas
+        def describe(self) -> list[dict]: ...  # list of OpenAI-compatible function schemas
 
-        def call(self, tool_name: str, arguments: dict) -> str:
-            ...  # execute the tool, return a string
+        def call(self, tool_name: str, arguments: dict) -> str: ...  # execute the tool, return a string
 
 If ``describe()`` is absent the provider synthesises a single-tool definition
 from the ``description`` and ``parameters`` fields in the spec.
@@ -33,7 +31,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-from .base import ToolDefinition, ToolError, ToolNotFoundError, ToolProvider
+from .base import ToolDefinition, ToolError, ToolProvider
 
 
 class CustomToolProvider(ToolProvider):
@@ -65,7 +63,9 @@ class CustomToolProvider(ToolProvider):
                 ToolDefinition(
                     name=d["name"],
                     description=d.get("description", ""),
-                    parameters=d.get("parameters", {"type": "object", "properties": {}}),
+                    parameters=d.get(
+                        "parameters", {"type": "object", "properties": {}}
+                    ),
                 )
                 for d in raw
             ]

--- a/oas_cli/tool_providers/mcp.py
+++ b/oas_cli/tool_providers/mcp.py
@@ -1,0 +1,261 @@
+"""MCP (Model Context Protocol) tool provider — raw HTTP, no MCP SDK required.
+
+Connects to any MCP server that speaks JSON-RPC 2.0 over HTTP.  OAS calls
+``tools/list`` once on first use to discover available tools, then
+``tools/call`` for each model-requested invocation.
+
+Spec example
+------------
+tools:
+  github:
+    type: mcp
+    endpoint: "http://localhost:3000"
+    description: "GitHub tools via MCP"          # optional — overrides server name
+    timeout: 30                                   # optional, default 30s
+    headers:                                      # optional extra headers
+      Authorization: "Bearer ${GITHUB_TOKEN}"
+
+  # point at a remote/hosted MCP server
+  brave_search:
+    type: mcp
+    endpoint: "https://mcp.brave.com"
+    headers:
+      X-API-Key: "${BRAVE_API_KEY}"
+
+tasks:
+  research:
+    tools: [github, brave_search]
+
+Security note
+-------------
+Errors from an MCP server surface as ``ToolError`` and never crash the runner.
+OAS is the caller — it does not host or execute server-side code, so a
+misbehaving MCP server affects only the tool result for that call.
+
+Environment variable interpolation
+-----------------------------------
+Values in ``headers`` that look like ``${VAR_NAME}`` are expanded from the
+environment at call time, keeping secrets out of spec files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .base import ToolDefinition, ToolError, ToolNotFoundError, ToolProvider
+
+_DEFAULT_TIMEOUT = 30
+_ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _expand_env(value: str) -> str:
+    """Replace ``${VAR_NAME}`` patterns with environment variable values."""
+    def _replace(match: re.Match) -> str:
+        var = match.group(1)
+        resolved = os.environ.get(var, "")
+        if not resolved:
+            import warnings
+            warnings.warn(
+                f"[mcp] Environment variable '{var}' referenced in tool config is not set.",
+                stacklevel=3,
+            )
+        return resolved
+    return _ENV_VAR_RE.sub(_replace, value)
+
+
+def _resolve_headers(raw: dict[str, str] | None) -> dict[str, str]:
+    """Expand env vars in header values and return a plain dict."""
+    if not raw:
+        return {}
+    return {k: _expand_env(str(v)) for k, v in raw.items()}
+
+
+def _jsonrpc(
+    endpoint: str,
+    method: str,
+    params: dict | None,
+    request_id: int,
+    extra_headers: dict[str, str],
+    timeout: int,
+) -> Any:
+    """Send a JSON-RPC 2.0 request and return the ``result`` field.
+
+    Raises:
+        ToolError: On any HTTP error or JSON-RPC error response.
+    """
+    payload = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "id": request_id,
+    }
+    if params is not None:
+        payload["params"] = params
+
+    all_headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        **extra_headers,
+    }
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(endpoint, data=body, headers=all_headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise ToolError(f"MCP HTTP {exc.code} from {endpoint}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise ToolError(f"MCP connection failed ({endpoint}): {exc.reason}") from exc
+    except Exception as exc:
+        raise ToolError(f"MCP request to {endpoint} failed: {exc}") from exc
+
+    if "error" in data:
+        err = data["error"]
+        raise ToolError(
+            f"MCP error from {endpoint} [{method}]: "
+            f"code={err.get('code')} message={err.get('message')}"
+        )
+
+    return data.get("result")
+
+
+class MCPToolProvider(ToolProvider):
+    """Connects to an MCP server and exposes its tools to OAS tasks.
+
+    Tool discovery (``tools/list``) is lazy — it happens on the first call to
+    ``describe()`` or ``call()`` and the result is cached for the lifetime of
+    the provider instance.
+    """
+
+    def __init__(self, tool_name: str, tool_config: dict[str, Any]) -> None:
+        self._tool_name = tool_name
+        endpoint: str = tool_config.get("endpoint", "")
+        if not endpoint:
+            raise ToolError(
+                f"MCP tool '{tool_name}' must specify an 'endpoint' "
+                "(e.g. endpoint: http://localhost:3000)."
+            )
+        self._endpoint = endpoint.rstrip("/")
+        self._timeout = int(tool_config.get("timeout", _DEFAULT_TIMEOUT))
+        self._extra_headers = _resolve_headers(tool_config.get("headers"))
+        self._override_description: str | None = tool_config.get("description")
+        self._cached_definitions: list[ToolDefinition] | None = None
+        self._req_id = 0
+
+    def _next_id(self) -> int:
+        self._req_id += 1
+        return self._req_id
+
+    def _fetch_tools(self) -> list[ToolDefinition]:
+        """Call ``tools/list`` and convert to ``ToolDefinition`` objects."""
+        result = _jsonrpc(
+            endpoint=self._endpoint,
+            method="tools/list",
+            params=None,
+            request_id=self._next_id(),
+            extra_headers=self._extra_headers,
+            timeout=self._timeout,
+        )
+
+        raw_tools: list[dict] = []
+        if isinstance(result, dict):
+            raw_tools = result.get("tools", [])
+        elif isinstance(result, list):
+            raw_tools = result
+
+        if not raw_tools:
+            raise ToolError(
+                f"MCP server at {self._endpoint} returned no tools from tools/list."
+            )
+
+        definitions = []
+        for t in raw_tools:
+            name = t.get("name", "")
+            description = t.get("description", self._override_description or "")
+            # MCP uses ``inputSchema``; fall back to an empty object schema.
+            parameters = t.get("inputSchema") or t.get("input_schema") or {
+                "type": "object",
+                "properties": {},
+            }
+            definitions.append(
+                ToolDefinition(
+                    name=name,
+                    description=description,
+                    parameters=parameters,
+                )
+            )
+        return definitions
+
+    def describe(self) -> list[ToolDefinition]:
+        if self._cached_definitions is None:
+            self._cached_definitions = self._fetch_tools()
+        return self._cached_definitions
+
+    def call(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        # Ensure we've discovered tools so we can validate the name.
+        known = {d.name for d in self.describe()}
+        if tool_name not in known:
+            raise ToolNotFoundError(
+                f"MCP server at {self._endpoint} does not expose tool '{tool_name}'. "
+                f"Available: {sorted(known)}"
+            )
+
+        result = _jsonrpc(
+            endpoint=self._endpoint,
+            method="tools/call",
+            params={"name": tool_name, "arguments": arguments},
+            request_id=self._next_id(),
+            extra_headers=self._extra_headers,
+            timeout=self._timeout,
+        )
+
+        return _extract_call_result(result, tool_name, self._endpoint)
+
+
+def _extract_call_result(result: Any, tool_name: str, endpoint: str) -> str:
+    """Normalise the MCP ``tools/call`` result to a plain string.
+
+    MCP servers return results in different shapes:
+      - ``{"content": [{"type": "text", "text": "..."}]}``   (most common)
+      - ``{"content": "..."}``                               (simplified)
+      - a bare string
+      - ``{"result": "..."}``
+
+    We always give the model a string.
+    """
+    if result is None:
+        return ""
+
+    if isinstance(result, str):
+        return result
+
+    if isinstance(result, dict):
+        # Standard MCP content block list
+        content = result.get("content")
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+                elif isinstance(block, str):
+                    parts.append(block)
+            return "\n".join(parts)
+
+        if isinstance(content, str):
+            return content
+
+        # Some servers put the result directly
+        if "result" in result:
+            return str(result["result"])
+
+        # Fallback: serialise the whole dict
+        return json.dumps(result)
+
+    # Lists, numbers, booleans — serialise as JSON
+    return json.dumps(result)

--- a/oas_cli/tool_providers/mcp.py
+++ b/oas_cli/tool_providers/mcp.py
@@ -55,16 +55,19 @@ _ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
 def _expand_env(value: str) -> str:
     """Replace ``${VAR_NAME}`` patterns with environment variable values."""
+
     def _replace(match: re.Match) -> str:
         var = match.group(1)
         resolved = os.environ.get(var, "")
         if not resolved:
             import warnings
+
             warnings.warn(
                 f"[mcp] Environment variable '{var}' referenced in tool config is not set.",
                 stacklevel=3,
             )
         return resolved
+
     return _ENV_VAR_RE.sub(_replace, value)
 
 
@@ -102,7 +105,9 @@ def _jsonrpc(
         **extra_headers,
     }
     body = json.dumps(payload).encode()
-    req = urllib.request.Request(endpoint, data=body, headers=all_headers, method="POST")
+    req = urllib.request.Request(
+        endpoint, data=body, headers=all_headers, method="POST"
+    )
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -179,10 +184,14 @@ class MCPToolProvider(ToolProvider):
             name = t.get("name", "")
             description = t.get("description", self._override_description or "")
             # MCP uses ``inputSchema``; fall back to an empty object schema.
-            parameters = t.get("inputSchema") or t.get("input_schema") or {
-                "type": "object",
-                "properties": {},
-            }
+            parameters = (
+                t.get("inputSchema")
+                or t.get("input_schema")
+                or {
+                    "type": "object",
+                    "properties": {},
+                }
+            )
             definitions.append(
                 ToolDefinition(
                     name=name,

--- a/oas_cli/tool_providers/native.py
+++ b/oas_cli/tool_providers/native.py
@@ -33,13 +33,16 @@ _NATIVE_TOOLS: dict[str, tuple[ToolDefinition, Any]] = {}
 
 def _register(tool_id: str, defn: ToolDefinition):
     """Decorator that registers a handler under *tool_id*."""
+
     def decorator(fn):
         _NATIVE_TOOLS[tool_id] = (defn, fn)
         return fn
+
     return decorator
 
 
 # ── file.read ─────────────────────────────────────────────────────────────────
+
 
 @_register(
     "file.read",
@@ -70,6 +73,7 @@ def _file_read(path: str) -> str:
 
 
 # ── file.write ────────────────────────────────────────────────────────────────
+
 
 @_register(
     "file.write",
@@ -106,6 +110,7 @@ def _file_write(path: str, content: str) -> str:
 
 # ── http.get ──────────────────────────────────────────────────────────────────
 
+
 @_register(
     "http.get",
     ToolDefinition(
@@ -139,6 +144,7 @@ def _http_get(url: str, headers: dict | None = None) -> str:
 
 
 # ── http.post ─────────────────────────────────────────────────────────────────
+
 
 @_register(
     "http.post",
@@ -180,6 +186,7 @@ def _http_post(url: str, body: dict, headers: dict | None = None) -> str:
 
 # ── env.read ──────────────────────────────────────────────────────────────────
 
+
 @_register(
     "env.read",
     ToolDefinition(
@@ -202,6 +209,7 @@ def _env_read(name: str) -> str:
 
 
 # ── Provider class ────────────────────────────────────────────────────────────
+
 
 class NativeToolProvider(ToolProvider):
     """Exposes a subset of native OAS tools declared in the spec.
@@ -234,7 +242,9 @@ class NativeToolProvider(ToolProvider):
                     raise
                 except Exception as exc:
                     raise ToolError(f"native tool '{tool_name}' raised: {exc}") from exc
-        raise ToolNotFoundError(f"Native tool '{tool_name}' is not enabled for this task.")
+        raise ToolNotFoundError(
+            f"Native tool '{tool_name}' is not enabled for this task."
+        )
 
 
 def available_native_tools() -> list[str]:

--- a/oas_cli/tool_providers/native.py
+++ b/oas_cli/tool_providers/native.py
@@ -1,0 +1,242 @@
+"""Native OAS tools — zero external dependencies, sandboxed by design.
+
+Available tools
+---------------
+file.read   Read a file and return its text content.
+file.write  Write text content to a file (creates parent dirs).
+http.get    Perform an HTTP GET and return the response body.
+http.post   Perform an HTTP POST with a JSON payload and return the response body.
+env.read    Read a single environment variable (empty string if unset).
+
+Security note
+-------------
+``file.read`` / ``file.write`` operate on paths as given.  In production you
+should add an allow-list in the spec (``allowed_paths:`` — future work).
+``http.get`` / ``http.post`` make real network requests; restrict with
+``allowed_hosts:`` when needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from .base import ToolDefinition, ToolError, ToolNotFoundError, ToolProvider
+
+# Registry: tool_id → (ToolDefinition, handler)
+_NATIVE_TOOLS: dict[str, tuple[ToolDefinition, Any]] = {}
+
+
+def _register(tool_id: str, defn: ToolDefinition):
+    """Decorator that registers a handler under *tool_id*."""
+    def decorator(fn):
+        _NATIVE_TOOLS[tool_id] = (defn, fn)
+        return fn
+    return decorator
+
+
+# ── file.read ─────────────────────────────────────────────────────────────────
+
+@_register(
+    "file.read",
+    ToolDefinition(
+        name="file_read",
+        description="Read a file from the filesystem and return its text content.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the file to read.",
+                },
+            },
+            "required": ["path"],
+        },
+    ),
+)
+def _file_read(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ToolError(f"file.read: file not found: {path}") from exc
+    except PermissionError as exc:
+        raise ToolError(f"file.read: permission denied: {path}") from exc
+    except Exception as exc:
+        raise ToolError(f"file.read: {exc}") from exc
+
+
+# ── file.write ────────────────────────────────────────────────────────────────
+
+@_register(
+    "file.write",
+    ToolDefinition(
+        name="file_write",
+        description="Write text content to a file. Parent directories are created if needed.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the file to write.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Text content to write.",
+                },
+            },
+            "required": ["path", "content"],
+        },
+    ),
+)
+def _file_write(path: str, content: str) -> str:
+    try:
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return f"Written {len(content)} characters to {path}"
+    except PermissionError as exc:
+        raise ToolError(f"file.write: permission denied: {path}") from exc
+    except Exception as exc:
+        raise ToolError(f"file.write: {exc}") from exc
+
+
+# ── http.get ──────────────────────────────────────────────────────────────────
+
+@_register(
+    "http.get",
+    ToolDefinition(
+        name="http_get",
+        description="Perform an HTTP GET request and return the response body as text.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to fetch.",
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Optional HTTP headers as key-value pairs.",
+                },
+            },
+            "required": ["url"],
+        },
+    ),
+)
+def _http_get(url: str, headers: dict | None = None) -> str:
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as exc:
+        raise ToolError(f"http.get HTTP {exc.code}: {url}") from exc
+    except Exception as exc:
+        raise ToolError(f"http.get failed for {url}: {exc}") from exc
+
+
+# ── http.post ─────────────────────────────────────────────────────────────────
+
+@_register(
+    "http.post",
+    ToolDefinition(
+        name="http_post",
+        description="Perform an HTTP POST with a JSON body and return the response body as text.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to POST to.",
+                },
+                "body": {
+                    "type": "object",
+                    "description": "JSON-serialisable payload to send as the request body.",
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Optional additional HTTP headers.",
+                },
+            },
+            "required": ["url", "body"],
+        },
+    ),
+)
+def _http_post(url: str, body: dict, headers: dict | None = None) -> str:
+    all_headers = {"Content-Type": "application/json", **(headers or {})}
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, headers=all_headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as exc:
+        raise ToolError(f"http.post HTTP {exc.code}: {url}") from exc
+    except Exception as exc:
+        raise ToolError(f"http.post failed for {url}: {exc}") from exc
+
+
+# ── env.read ──────────────────────────────────────────────────────────────────
+
+@_register(
+    "env.read",
+    ToolDefinition(
+        name="env_read",
+        description="Read an environment variable. Returns an empty string if the variable is not set.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The environment variable name.",
+                },
+            },
+            "required": ["name"],
+        },
+    ),
+)
+def _env_read(name: str) -> str:
+    return os.environ.get(name, "")
+
+
+# ── Provider class ────────────────────────────────────────────────────────────
+
+class NativeToolProvider(ToolProvider):
+    """Exposes a subset of native OAS tools declared in the spec.
+
+    The spec names which native tool IDs are enabled for a task (e.g.
+    ``file.read``, ``http.get``).  This provider exposes only those, so the
+    model never sees tools it isn't supposed to call.
+    """
+
+    def __init__(self, enabled_ids: list[str]) -> None:
+        unknown = [t for t in enabled_ids if t not in _NATIVE_TOOLS]
+        if unknown:
+            raise ToolError(
+                f"Unknown native tool(s): {', '.join(unknown)}. "
+                f"Available: {', '.join(_NATIVE_TOOLS)}"
+            )
+        self._enabled = enabled_ids
+
+    def describe(self) -> list[ToolDefinition]:
+        return [_NATIVE_TOOLS[tid][0] for tid in self._enabled]
+
+    def call(self, tool_name: str, arguments: dict) -> str:
+        # tool_name is the function name (e.g. "file_read"), map back to tool_id
+        for tid in self._enabled:
+            defn, handler = _NATIVE_TOOLS[tid]
+            if defn.name == tool_name:
+                try:
+                    return handler(**arguments)
+                except ToolError:
+                    raise
+                except Exception as exc:
+                    raise ToolError(f"native tool '{tool_name}' raised: {exc}") from exc
+        raise ToolNotFoundError(f"Native tool '{tool_name}' is not enabled for this task.")
+
+
+def available_native_tools() -> list[str]:
+    """Return all registered native tool IDs."""
+    return list(_NATIVE_TOOLS.keys())

--- a/oas_cli/tool_providers/registry.py
+++ b/oas_cli/tool_providers/registry.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import ToolDefinition, ToolError, ToolNotFoundError, ToolProvider, ToolTypeNotSupportedError
+from .base import (
+    ToolDefinition,
+    ToolError,
+    ToolNotFoundError,
+    ToolProvider,
+    ToolTypeNotSupportedError,
+)
 from .custom import CustomToolProvider
 from .mcp import MCPToolProvider
 from .native import NativeToolProvider, available_native_tools
@@ -90,6 +96,4 @@ def dispatch_tool_call(
     for provider, defn in providers_and_defs:
         if defn.name == tool_name:
             return provider.call(tool_name, arguments)
-    raise ToolNotFoundError(
-        f"No tool named '{tool_name}' is registered for this task."
-    )
+    raise ToolNotFoundError(f"No tool named '{tool_name}' is registered for this task.")

--- a/oas_cli/tool_providers/registry.py
+++ b/oas_cli/tool_providers/registry.py
@@ -1,0 +1,95 @@
+"""Tool provider registry — resolves spec tool declarations to ToolProvider instances."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ToolDefinition, ToolError, ToolNotFoundError, ToolProvider, ToolTypeNotSupportedError
+from .custom import CustomToolProvider
+from .mcp import MCPToolProvider
+from .native import NativeToolProvider, available_native_tools
+
+
+def get_tool_provider(tool_name: str, tool_config: dict[str, Any]) -> ToolProvider:
+    """Return the correct ``ToolProvider`` for a single tool declaration.
+
+    Supported types
+    ---------------
+    native   — built-in OAS tools (file.read, file.write, http.get, …)
+    mcp      — any MCP server (JSON-RPC 2.0 over HTTP, no MCP SDK required)
+    custom   — user-provided Python class
+    """
+    tool_type = tool_config.get("type", "native")
+
+    if tool_type == "native":
+        native_id = tool_config.get("native")
+        if not native_id:
+            raise ToolError(
+                f"Tool '{tool_name}' has type 'native' but is missing the 'native' field "
+                f"(e.g. native: file.read). Available: {available_native_tools()}"
+            )
+        return NativeToolProvider(enabled_ids=[native_id])
+
+    if tool_type == "mcp":
+        return MCPToolProvider(tool_name=tool_name, tool_config=tool_config)
+
+    if tool_type == "custom":
+        return CustomToolProvider(tool_name=tool_name, tool_config=tool_config)
+
+    raise ToolTypeNotSupportedError(
+        f"Tool '{tool_name}' has unsupported type '{tool_type}'. "
+        "Supported types: native, mcp, custom."
+    )
+
+
+def resolve_task_tools(
+    spec_data: dict[str, Any],
+    task_name: str,
+) -> list[tuple[ToolProvider, ToolDefinition]]:
+    """Return (provider, definition) pairs for every tool enabled on *task_name*.
+
+    Returns an empty list when the task declares no tools.
+    """
+    spec_tools: dict[str, Any] = spec_data.get("tools") or {}
+    tasks: dict[str, Any] = spec_data.get("tasks") or {}
+    task_def: dict[str, Any] = tasks.get(task_name) or {}
+    task_tool_names: list[str] = task_def.get("tools") or []
+
+    if not task_tool_names:
+        return []
+
+    result: list[tuple[ToolProvider, ToolDefinition]] = []
+    for name in task_tool_names:
+        tool_cfg = spec_tools.get(name)
+        if tool_cfg is None:
+            raise ToolError(
+                f"Task '{task_name}' references tool '{name}' which is not declared "
+                "in the top-level 'tools:' block."
+            )
+        provider = get_tool_provider(name, tool_cfg)
+        for defn in provider.describe():
+            result.append((provider, defn))
+
+    return result
+
+
+def all_tool_definitions(
+    spec_data: dict[str, Any],
+    task_name: str,
+) -> list[ToolDefinition]:
+    """Convenience helper — return only the ToolDefinition objects."""
+    return [defn for _, defn in resolve_task_tools(spec_data, task_name)]
+
+
+def dispatch_tool_call(
+    tool_name: str,
+    arguments: dict[str, Any],
+    providers_and_defs: list[tuple[ToolProvider, ToolDefinition]],
+) -> str:
+    """Find the provider that owns *tool_name* and execute the call."""
+    for provider, defn in providers_and_defs:
+        if defn.name == tool_name:
+            return provider.call(tool_name, arguments)
+    raise ToolNotFoundError(
+        f"No tool named '{tool_name}' is registered for this task."
+    )

--- a/oas_cli/validators.py
+++ b/oas_cli/validators.py
@@ -122,69 +122,73 @@ def _validate_behavioural_contract(spec_data: dict) -> None:
             )
 
 
+_VALID_TOOL_TYPES = {"native", "mcp", "custom"}
+_VALID_NATIVE_IDS = {"file.read", "file.write", "http.get", "http.post", "env.read"}
+
+
 def _validate_tools(spec_data: dict) -> None:
-    """Validate the tools section."""
-    tools = spec_data.get("tools", [])
-    if not isinstance(tools, list):
+    """Validate the top-level tools: block (dict of named tool declarations)."""
+    tools = spec_data.get("tools")
+    if tools is None:
+        return
+
+    if not isinstance(tools, dict):
         actual_type = type(tools).__name__
         raise ValueError(
-            f"Field 'tools' must be a list (array), got {actual_type}. "
-            "Example:\n  tools:\n    - id: tool1\n"
-            '      type: function\n      description: "..."'
+            f"Field 'tools' must be a dictionary (object), got {actual_type}. "
+            "Example:\n  tools:\n    read_file:\n      type: native\n"
+            "      native: file.read"
         )
 
-    for i, tool in enumerate(tools):
-        if not isinstance(tool, dict):
-            actual_type = type(tool).__name__
+    for tool_name, tool_cfg in tools.items():
+        if not isinstance(tool_cfg, dict):
             raise ValueError(
-                f"tools[{i}] must be a dictionary (object), "
-                f"got {actual_type}. "
-                "Each tool should have 'id', 'type', and "
-                "'description' fields."
+                f"tools.{tool_name} must be a dictionary (object), "
+                f"got {type(tool_cfg).__name__}."
             )
 
-        if not isinstance(tool.get("id"), str):
-            actual_type = type(tool.get("id")).__name__ if "id" in tool else "missing"
+        tool_type = tool_cfg.get("type")
+        if tool_type not in _VALID_TOOL_TYPES:
             raise ValueError(
-                f"tools[{i}].id must be a string, got {actual_type}. "
-                'Provide a unique identifier, e.g., id: "web_search"'
+                f"tools.{tool_name}.type must be one of "
+                f"{sorted(_VALID_TOOL_TYPES)}, got '{tool_type}'."
             )
 
-        if not isinstance(tool.get("description"), str):
-            actual_type = (
-                type(tool.get("description")).__name__
-                if "description" in tool
-                else "missing"
-            )
+        if tool_type == "native":
+            native_id = tool_cfg.get("native")
+            if not native_id:
+                raise ValueError(
+                    f"tools.{tool_name} has type 'native' but is missing the "
+                    f"'native' field. Available: {sorted(_VALID_NATIVE_IDS)}"
+                )
+            if native_id not in _VALID_NATIVE_IDS:
+                raise ValueError(
+                    f"tools.{tool_name}.native '{native_id}' is not a recognised "
+                    f"native tool. Available: {sorted(_VALID_NATIVE_IDS)}"
+                )
+
+        if tool_type == "mcp" and not tool_cfg.get("endpoint"):
             raise ValueError(
-                f"tools[{i}].description must be a string, "
-                f"got {actual_type}. "
-                "Provide a description of what this tool does."
+                f"tools.{tool_name} has type 'mcp' but is missing the "
+                "'endpoint' field (e.g. endpoint: http://localhost:3000)."
             )
 
-        if not isinstance(tool.get("type"), str):
-            actual_type = (
-                type(tool.get("type")).__name__ if "type" in tool else "missing"
-            )
+        if tool_type == "custom" and not tool_cfg.get("module"):
             raise ValueError(
-                f"tools[{i}].type must be a string, got {actual_type}. "
-                'Common values: "function", "api", "file_operation"'
+                f"tools.{tool_name} has type 'custom' but is missing the "
+                "'module' field (e.g. module: my_package.MyTool)."
             )
-
-        # Validate allowed_paths if present (for file operations)
-        if "allowed_paths" in tool:
-            if not isinstance(tool["allowed_paths"], list):
-                raise ValueError(f"tool {i}.allowed_paths must be a list")
-            for j, path in enumerate(tool["allowed_paths"]):
-                if not isinstance(path, str):
-                    raise ValueError(f"tool {i}.allowed_paths[{j}] must be a string")
 
 
 def _validate_tasks(spec_data: dict) -> None:
     """Validate the tasks section."""
     tasks = spec_data.get("tasks", {})
-    tools = spec_data.get("tools", [])
-    tool_ids = [tool["id"] for tool in tools]
+    tools = spec_data.get("tools") or {}
+    # Support both the new dict format and the legacy list format gracefully.
+    if isinstance(tools, dict):
+        tool_ids = list(tools.keys())
+    else:
+        tool_ids = [t["id"] for t in tools if isinstance(t, dict) and "id" in t]
 
     if not isinstance(tasks, dict):
         actual_type = type(tasks).__name__
@@ -205,7 +209,7 @@ def _validate_tasks(spec_data: dict) -> None:
                 "definitions."
             )
 
-        # Check if this task uses a tool
+        # Check if this task uses a tool (legacy single string)
         if "tool" in task_def:
             tool_id = task_def["tool"]
             if not isinstance(tool_id, str):
@@ -213,16 +217,37 @@ def _validate_tasks(spec_data: dict) -> None:
                 raise ValueError(
                     f"tasks.{task_name}.tool must be a string, got {actual_type}."
                 )
-            if tool_id not in tool_ids:
-                available = (
-                    ", ".join(f"'{tid}'" for tid in tool_ids) if tool_ids else "none"
-                )
+            if tool_ids and tool_id not in tool_ids:
+                available = ", ".join(f"'{tid}'" for tid in tool_ids)
                 raise ValueError(
                     f"tasks.{task_name} references non-existent "
                     f"tool '{tool_id}'. "
                     f"Available tools: {available}. "
                     "Check your 'tools' section."
                 )
+
+        # Check if this task uses tools (new list format)
+        if "tools" in task_def:
+            task_tools = task_def["tools"]
+            if not isinstance(task_tools, list):
+                raise ValueError(
+                    f"tasks.{task_name}.tools must be a list of tool names, "
+                    f"got {type(task_tools).__name__}."
+                )
+            for ref in task_tools:
+                if not isinstance(ref, str):
+                    raise ValueError(
+                        f"tasks.{task_name}.tools entries must be strings, "
+                        f"got {type(ref).__name__}."
+                    )
+                if tool_ids and ref not in tool_ids:
+                    available = ", ".join(f"'{tid}'" for tid in tool_ids)
+                    raise ValueError(
+                        f"tasks.{task_name}.tools references undeclared "
+                        f"tool '{ref}'. "
+                        f"Available tools: {available}. "
+                        "Check your top-level 'tools:' section."
+                    )
 
         # Check if this is a multi-step task
         is_multi_step = task_def.get("multi_step", False)
@@ -352,11 +377,17 @@ def _validate_integration(spec_data: dict) -> None:
 
 
 def _validate_prompts(spec_data: dict) -> None:
-    """Validate the prompts section."""
-    prompts = spec_data.get("prompts", {})
-    if not isinstance(prompts.get("system"), str):
+    """Validate the prompts section (global fallback — optional)."""
+    prompts = spec_data.get("prompts")
+    if not prompts:
+        return
+    if not isinstance(prompts, dict):
+        raise ValueError(
+            f"Field 'prompts' must be a dictionary, got {type(prompts).__name__}."
+        )
+    if "system" in prompts and not isinstance(prompts["system"], str):
         raise ValueError("prompts.system must be a string")
-    if not isinstance(prompts.get("user"), str):
+    if "user" in prompts and not isinstance(prompts["user"], str):
         raise ValueError("prompts.user must be a string")
 
 

--- a/tests/test_tool_providers.py
+++ b/tests/test_tool_providers.py
@@ -13,11 +13,6 @@ Covers:
 from __future__ import annotations
 
 import json
-import os
-import tempfile
-import unittest
-from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,7 +20,6 @@ import pytest
 from oas_cli.tool_providers.base import (
     InvokeResult,
     ToolCall,
-    ToolDefinition,
     ToolError,
     ToolNotFoundError,
     ToolTypeNotSupportedError,
@@ -37,7 +31,6 @@ from oas_cli.tool_providers.registry import (
     get_tool_provider,
     resolve_task_tools,
 )
-
 
 # ── NativeToolProvider ────────────────────────────────────────────────────────
 
@@ -130,7 +123,9 @@ class TestNativeToolProvider:
         response_mock.__enter__ = lambda s: response_mock
         response_mock.__exit__ = MagicMock(return_value=False)
         with patch("urllib.request.urlopen", return_value=response_mock):
-            result = p.call("http_post", {"url": "https://api.example.com", "body": {"k": "v"}})
+            result = p.call(
+                "http_post", {"url": "https://api.example.com", "body": {"k": "v"}}
+            )
         assert '{"status":"ok"}' in result
 
     # ── call routing ───────────────────────────────────────────────────────
@@ -256,7 +251,9 @@ class TestCustomToolProvider:
 
 class TestRegistry:
     def test_get_provider_native(self):
-        provider = get_tool_provider("read_file", {"type": "native", "native": "file.read"})
+        provider = get_tool_provider(
+            "read_file", {"type": "native", "native": "file.read"}
+        )
         assert isinstance(provider, NativeToolProvider)
 
     def test_get_provider_unknown_type_raises(self):
@@ -336,14 +333,21 @@ class TestInvokeWithToolsLoop:
             "tasks": {
                 "ask": {
                     "description": "Ask something",
-                    "output": {"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]},
+                    "output": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                        "required": ["answer"],
+                    },
                     "tools": ["get_env"],
                 }
             },
             "tools": {
                 "get_env": {"type": "native", "native": "env.read"},
             },
-            "prompts": {"system": "You are a helpful assistant.", "user": "What is PATH?"},
+            "prompts": {
+                "system": "You are a helpful assistant.",
+                "user": "What is PATH?",
+            },
         }
 
     def test_single_turn_final_answer(self):
@@ -372,7 +376,9 @@ class TestInvokeWithToolsLoop:
         monkeypatch.setenv("MY_TEST_ENV", "42")
         spec = self._make_spec()
 
-        tool_call = ToolCall(id="call_1", name="env_read", arguments={"name": "MY_TEST_ENV"})
+        tool_call = ToolCall(
+            id="call_1", name="env_read", arguments={"name": "MY_TEST_ENV"}
+        )
         turn1 = InvokeResult(is_final=False, tool_calls=[tool_call])
         turn2 = InvokeResult(is_final=True, text='{"answer": "42"}')
 
@@ -392,7 +398,9 @@ class TestInvokeWithToolsLoop:
         assert result == '{"answer": "42"}'
         assert mock_provider.invoke_with_tools.call_count == 2
         # Verify the tool result was injected into the second call's messages
-        second_call_messages = mock_provider.invoke_with_tools.call_args_list[1][1]["messages"]
+        second_call_messages = mock_provider.invoke_with_tools.call_args_list[1][1][
+            "messages"
+        ]
         tool_msg = next(m for m in second_call_messages if m.get("role") == "tool")
         assert tool_msg["content"] == "42"
 
@@ -403,14 +411,22 @@ class TestInvokeWithToolsLoop:
         mock_provider = MagicMock()
         mock_provider.supports_tools.return_value = False
 
-        with patch("oas_cli.runner.get_provider", return_value=mock_provider), \
-             patch("oas_cli.runner.invoke_intelligence", return_value='{"answer":"ok"}') as mock_invoke:
+        with (
+            patch("oas_cli.runner.get_provider", return_value=mock_provider),
+            patch(
+                "oas_cli.runner.invoke_intelligence", return_value='{"answer":"ok"}'
+            ) as mock_invoke,
+        ):
             from oas_cli.runner import _invoke_with_tools
             from oas_cli.tool_providers.registry import resolve_task_tools
 
             tools = resolve_task_tools(spec, "ask")
             result = _invoke_with_tools(
-                "You are helpful.", "user", tools, {"engine": "codex", "model": "x"}, "ask"
+                "You are helpful.",
+                "user",
+                tools,
+                {"engine": "codex", "model": "x"},
+                "ask",
             )
 
         mock_invoke.assert_called_once()
@@ -419,7 +435,7 @@ class TestInvokeWithToolsLoop:
 
     def test_loop_cap_raises_run_error(self):
         """Loop exits with OARunError after _MAX_TOOL_ITERATIONS."""
-        from oas_cli.runner import OARunError, _MAX_TOOL_ITERATIONS
+        from oas_cli.runner import _MAX_TOOL_ITERATIONS, OARunError
 
         spec = self._make_spec()
         tool_call = ToolCall(id="call_1", name="env_read", arguments={"name": "X"})
@@ -436,7 +452,11 @@ class TestInvokeWithToolsLoop:
             tools = resolve_task_tools(spec, "ask")
             with pytest.raises(OARunError, match="exceeded"):
                 _invoke_with_tools(
-                    "system", "user", tools, {"engine": "openai", "model": "gpt-4o"}, "ask"
+                    "system",
+                    "user",
+                    tools,
+                    {"engine": "openai", "model": "gpt-4o"},
+                    "ask",
                 )
 
         assert mock_provider.invoke_with_tools.call_count == _MAX_TOOL_ITERATIONS
@@ -447,7 +467,6 @@ class TestInvokeWithToolsLoop:
 
 def _mock_urlopen(responses: list[dict]):
     """Return a context manager mock that yields JSON responses in order."""
-    import io
 
     call_count = {"n": 0}
 
@@ -502,11 +521,7 @@ _LIST_RESPONSE = {
 _CALL_RESPONSE = {
     "jsonrpc": "2.0",
     "id": 2,
-    "result": {
-        "content": [
-            {"type": "text", "text": "Paris is sunny and 22°C."}
-        ]
-    },
+    "result": {"content": [{"type": "text", "text": "Paris is sunny and 22°C."}]},
 }
 
 
@@ -529,7 +544,9 @@ class TestMCPToolProvider:
 
     def test_describe_calls_tools_list(self):
         p = self._provider()
-        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+        with patch(
+            "urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])
+        ):
             defs = p.describe()
 
         assert len(defs) == 2
@@ -549,7 +566,9 @@ class TestMCPToolProvider:
 
     def test_describe_parses_input_schema(self):
         p = self._provider()
-        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+        with patch(
+            "urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])
+        ):
             defs = p.describe()
 
         search = next(d for d in defs if d.name == "search_web")
@@ -558,7 +577,9 @@ class TestMCPToolProvider:
     def test_empty_tools_list_raises(self):
         p = self._provider()
         empty_response = {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
-        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([empty_response])):
+        with patch(
+            "urllib.request.urlopen", side_effect=_mock_urlopen([empty_response])
+        ):
             with pytest.raises(ToolError, match="no tools"):
                 p.describe()
 
@@ -576,7 +597,9 @@ class TestMCPToolProvider:
 
     def test_call_unknown_tool_raises(self):
         p = self._provider()
-        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+        with patch(
+            "urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])
+        ):
             with pytest.raises(ToolNotFoundError, match="magic_wand"):
                 p.call("magic_wand", {})
 
@@ -590,8 +613,12 @@ class TestMCPToolProvider:
             class _R:
                 def read(self):
                     return json.dumps(_CALL_RESPONSE).encode()
-                def __enter__(self): return self
-                def __exit__(self, *_): pass
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *_):
+                    pass
 
             return _R()
 
@@ -601,7 +628,9 @@ class TestMCPToolProvider:
             side_effect=[_mock_urlopen([_LIST_RESPONSE])("_"), _capture],
         ):
             # Seed the cache so only one HTTP round-trip happens
-            with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+            with patch(
+                "urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])
+            ):
                 p.describe()
             with patch("urllib.request.urlopen", _capture):
                 p.call("get_weather", {"location": "Paris"})
@@ -620,7 +649,12 @@ class TestMCPToolProvider:
     def test_extract_content_block_list(self):
         from oas_cli.tool_providers.mcp import _extract_call_result
 
-        result = {"content": [{"type": "text", "text": "foo"}, {"type": "text", "text": "bar"}]}
+        result = {
+            "content": [
+                {"type": "text", "text": "foo"},
+                {"type": "text", "text": "bar"},
+            ]
+        }
         assert _extract_call_result(result, "t", "http://x") == "foo\nbar"
 
     def test_extract_content_string(self):
@@ -652,8 +686,12 @@ class TestMCPToolProvider:
             class _R:
                 def read(self):
                     return json.dumps(_LIST_RESPONSE).encode()
-                def __enter__(self): return self
-                def __exit__(self, *_): pass
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *_):
+                    pass
 
             return _R()
 
@@ -697,7 +735,9 @@ class TestMCPToolProvider:
             "id": 1,
             "error": {"code": -32601, "message": "Method not found"},
         }
-        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([error_response])):
+        with patch(
+            "urllib.request.urlopen", side_effect=_mock_urlopen([error_response])
+        ):
             with pytest.raises(ToolError, match="Method not found"):
                 p.describe()
 
@@ -714,7 +754,9 @@ class TestMCPToolProvider:
 
     def test_to_openai_schema_shape(self):
         p = self._provider()
-        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+        with patch(
+            "urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])
+        ):
             defs = p.describe()
 
         schema = defs[0].to_openai_schema()

--- a/tests/test_tool_providers.py
+++ b/tests/test_tool_providers.py
@@ -1,0 +1,767 @@
+"""Tests for the OAS tool provider layer.
+
+Covers:
+- NativeToolProvider: all five built-in tools
+- CustomToolProvider: class loading, describe(), call()
+- MCPToolProvider: tools/list discovery, tools/call, result normalisation,
+  env-var header expansion, error handling
+- Registry helpers: get_tool_provider, resolve_task_tools, dispatch_tool_call
+- _invoke_with_tools loop in runner (multi-turn with mocks)
+- JSON schema: tools: block and per-task tools: array
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oas_cli.tool_providers.base import (
+    InvokeResult,
+    ToolCall,
+    ToolDefinition,
+    ToolError,
+    ToolNotFoundError,
+    ToolTypeNotSupportedError,
+)
+from oas_cli.tool_providers.custom import CustomToolProvider
+from oas_cli.tool_providers.native import NativeToolProvider, available_native_tools
+from oas_cli.tool_providers.registry import (
+    dispatch_tool_call,
+    get_tool_provider,
+    resolve_task_tools,
+)
+
+
+# ── NativeToolProvider ────────────────────────────────────────────────────────
+
+
+class TestNativeToolProvider:
+    def test_available_native_tools_contains_expected(self):
+        ids = available_native_tools()
+        assert "file.read" in ids
+        assert "file.write" in ids
+        assert "http.get" in ids
+        assert "http.post" in ids
+        assert "env.read" in ids
+
+    def test_unknown_tool_raises(self):
+        with pytest.raises(ToolError, match="Unknown native tool"):
+            NativeToolProvider(enabled_ids=["no.such.tool"])
+
+    def test_describe_returns_definitions(self):
+        p = NativeToolProvider(enabled_ids=["file.read", "env.read"])
+        defs = p.describe()
+        assert len(defs) == 2
+        names = {d.name for d in defs}
+        assert "file_read" in names
+        assert "env_read" in names
+
+    # ── file.read ──────────────────────────────────────────────────────────
+
+    def test_file_read_success(self, tmp_path):
+        f = tmp_path / "hello.txt"
+        f.write_text("world", encoding="utf-8")
+        p = NativeToolProvider(enabled_ids=["file.read"])
+        result = p.call("file_read", {"path": str(f)})
+        assert result == "world"
+
+    def test_file_read_not_found(self):
+        p = NativeToolProvider(enabled_ids=["file.read"])
+        with pytest.raises(ToolError, match="file not found"):
+            p.call("file_read", {"path": "/no/such/file.txt"})
+
+    # ── file.write ─────────────────────────────────────────────────────────
+
+    def test_file_write_creates_file(self, tmp_path):
+        dest = tmp_path / "sub" / "out.txt"
+        p = NativeToolProvider(enabled_ids=["file.write"])
+        result = p.call("file_write", {"path": str(dest), "content": "hello"})
+        assert dest.read_text() == "hello"
+        assert "Written" in result
+
+    # ── env.read ───────────────────────────────────────────────────────────
+
+    def test_env_read_existing_var(self, monkeypatch):
+        monkeypatch.setenv("_OA_TEST_VAR", "abc123")
+        p = NativeToolProvider(enabled_ids=["env.read"])
+        result = p.call("env_read", {"name": "_OA_TEST_VAR"})
+        assert result == "abc123"
+
+    def test_env_read_missing_var(self, monkeypatch):
+        monkeypatch.delenv("_OA_MISSING", raising=False)
+        p = NativeToolProvider(enabled_ids=["env.read"])
+        result = p.call("env_read", {"name": "_OA_MISSING"})
+        assert result == ""
+
+    # ── http.get (mocked) ──────────────────────────────────────────────────
+
+    def test_http_get_success(self):
+        p = NativeToolProvider(enabled_ids=["http.get"])
+        response_mock = MagicMock()
+        response_mock.read.return_value = b"OK response"
+        response_mock.__enter__ = lambda s: response_mock
+        response_mock.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=response_mock):
+            result = p.call("http_get", {"url": "https://example.com"})
+        assert result == "OK response"
+
+    def test_http_get_http_error(self):
+        import urllib.error
+
+        p = NativeToolProvider(enabled_ids=["http.get"])
+        err = urllib.error.HTTPError("https://example.com", 404, "Not Found", {}, None)
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(ToolError, match="HTTP 404"):
+                p.call("http_get", {"url": "https://example.com"})
+
+    # ── http.post (mocked) ─────────────────────────────────────────────────
+
+    def test_http_post_success(self):
+        p = NativeToolProvider(enabled_ids=["http.post"])
+        response_mock = MagicMock()
+        response_mock.read.return_value = b'{"status":"ok"}'
+        response_mock.__enter__ = lambda s: response_mock
+        response_mock.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=response_mock):
+            result = p.call("http_post", {"url": "https://api.example.com", "body": {"k": "v"}})
+        assert '{"status":"ok"}' in result
+
+    # ── call routing ───────────────────────────────────────────────────────
+
+    def test_call_unknown_tool_raises_not_found(self):
+        p = NativeToolProvider(enabled_ids=["env.read"])
+        with pytest.raises(ToolNotFoundError):
+            p.call("file_read", {"path": "/tmp/x"})
+
+    # ── openai schema ──────────────────────────────────────────────────────
+
+    def test_to_openai_schema(self):
+        p = NativeToolProvider(enabled_ids=["file.read"])
+        defs = p.describe()
+        schema = defs[0].to_openai_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "file_read"
+        assert "path" in schema["function"]["parameters"]["properties"]
+
+    def test_to_anthropic_schema(self):
+        p = NativeToolProvider(enabled_ids=["file.read"])
+        defs = p.describe()
+        schema = defs[0].to_anthropic_schema()
+        assert schema["name"] == "file_read"
+        assert "input_schema" in schema
+
+
+# ── CustomToolProvider ────────────────────────────────────────────────────────
+
+
+class _FakeTool:
+    """Minimal in-test custom tool class."""
+
+    def describe(self):
+        return [
+            {
+                "name": "fake_tool",
+                "description": "A fake tool for testing.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            }
+        ]
+
+    def call(self, tool_name: str, arguments: dict) -> str:
+        return f"FAKE:{arguments.get('text', '')}"
+
+
+class TestCustomToolProvider:
+    def test_loads_class_and_describes(self, monkeypatch):
+        # Inject fake class into sys.modules path
+        import sys
+        import types
+
+        mod = types.ModuleType("_test_fake_tools")
+        mod.FakeTool = _FakeTool
+        monkeypatch.setitem(sys.modules, "_test_fake_tools", mod)
+
+        p = CustomToolProvider(
+            tool_name="my_fake",
+            tool_config={"type": "custom", "module": "_test_fake_tools.FakeTool"},
+        )
+        defs = p.describe()
+        assert len(defs) == 1
+        assert defs[0].name == "fake_tool"
+
+    def test_calls_tool(self, monkeypatch):
+        import sys
+        import types
+
+        mod = types.ModuleType("_test_fake_tools2")
+        mod.FakeTool = _FakeTool
+        monkeypatch.setitem(sys.modules, "_test_fake_tools2", mod)
+
+        p = CustomToolProvider(
+            tool_name="my_fake",
+            tool_config={"type": "custom", "module": "_test_fake_tools2.FakeTool"},
+        )
+        result = p.call("fake_tool", {"text": "hello"})
+        assert result == "FAKE:hello"
+
+    def test_missing_module_raises(self):
+        with pytest.raises(ToolError, match="no_such_module"):
+            CustomToolProvider(
+                tool_name="x",
+                tool_config={"type": "custom", "module": "no_such_module.Class"},
+            )
+
+    def test_no_module_field_raises(self):
+        with pytest.raises(ToolError, match="must specify a 'module'"):
+            CustomToolProvider(tool_name="x", tool_config={"type": "custom"})
+
+    def test_synthesises_definition_without_describe(self, monkeypatch):
+        import sys
+        import types
+
+        class _MinimalTool:
+            def call(self, name, args):
+                return "ok"
+
+        mod = types.ModuleType("_test_minimal_tools")
+        mod.MinimalTool = _MinimalTool
+        monkeypatch.setitem(sys.modules, "_test_minimal_tools", mod)
+
+        p = CustomToolProvider(
+            tool_name="my_minimal",
+            tool_config={
+                "type": "custom",
+                "module": "_test_minimal_tools.MinimalTool",
+                "description": "Does something",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        )
+        defs = p.describe()
+        assert len(defs) == 1
+        assert defs[0].description == "Does something"
+
+
+# ── Registry helpers ──────────────────────────────────────────────────────────
+
+
+class TestRegistry:
+    def test_get_provider_native(self):
+        provider = get_tool_provider("read_file", {"type": "native", "native": "file.read"})
+        assert isinstance(provider, NativeToolProvider)
+
+    def test_get_provider_unknown_type_raises(self):
+        with pytest.raises(ToolTypeNotSupportedError):
+            get_tool_provider("x", {"type": "totally_unsupported"})
+
+    def test_get_provider_native_missing_native_field_raises(self):
+        with pytest.raises(ToolError, match="missing the 'native' field"):
+            get_tool_provider("x", {"type": "native"})
+
+    def test_resolve_task_tools_empty_when_no_tools(self):
+        spec = {
+            "tasks": {"my_task": {"description": "d", "output": {}}},
+        }
+        result = resolve_task_tools(spec, "my_task")
+        assert result == []
+
+    def test_resolve_task_tools_returns_pairs(self):
+        spec = {
+            "tools": {
+                "read_file": {"type": "native", "native": "file.read"},
+                "get_env": {"type": "native", "native": "env.read"},
+            },
+            "tasks": {
+                "my_task": {
+                    "description": "d",
+                    "output": {},
+                    "tools": ["read_file", "get_env"],
+                }
+            },
+        }
+        pairs = resolve_task_tools(spec, "my_task")
+        assert len(pairs) == 2
+        provider, defn = pairs[0]
+        assert defn.name == "file_read"
+
+    def test_resolve_task_tools_missing_top_level_raises(self):
+        spec = {
+            "tools": {},
+            "tasks": {
+                "my_task": {"description": "d", "output": {}, "tools": ["missing_tool"]}
+            },
+        }
+        with pytest.raises(ToolError, match="not declared"):
+            resolve_task_tools(spec, "my_task")
+
+    def test_dispatch_tool_call_success(self):
+        p = NativeToolProvider(enabled_ids=["env.read"])
+        defn = p.describe()[0]
+        pairs = [(p, defn)]
+        result = dispatch_tool_call("env_read", {"name": "PATH"}, pairs)
+        assert isinstance(result, str)
+
+    def test_dispatch_tool_call_unknown_raises(self):
+        p = NativeToolProvider(enabled_ids=["env.read"])
+        defn = p.describe()[0]
+        pairs = [(p, defn)]
+        with pytest.raises(ToolNotFoundError):
+            dispatch_tool_call("file_read", {"path": "/tmp/x"}, pairs)
+
+
+# ── _invoke_with_tools loop (runner integration) ──────────────────────────────
+
+
+class TestInvokeWithToolsLoop:
+    """Unit-tests for the multi-turn tool-call loop in runner.py."""
+
+    def _make_spec(self) -> dict:
+        return {
+            "open_agent_spec": "1.3.0",
+            "agent": {"name": "test", "description": "test"},
+            "intelligence": {
+                "type": "llm",
+                "engine": "openai",
+                "model": "gpt-4o",
+            },
+            "tasks": {
+                "ask": {
+                    "description": "Ask something",
+                    "output": {"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]},
+                    "tools": ["get_env"],
+                }
+            },
+            "tools": {
+                "get_env": {"type": "native", "native": "env.read"},
+            },
+            "prompts": {"system": "You are a helpful assistant.", "user": "What is PATH?"},
+        }
+
+    def test_single_turn_final_answer(self):
+        """Provider returns is_final immediately — no tool execution."""
+        spec = self._make_spec()
+        final_result = InvokeResult(is_final=True, text='{"answer": "direct"}')
+
+        mock_provider = MagicMock()
+        mock_provider.supports_tools.return_value = True
+        mock_provider.invoke_with_tools.return_value = final_result
+
+        with patch("oas_cli.runner.get_provider", return_value=mock_provider):
+            from oas_cli.runner import _invoke_with_tools
+            from oas_cli.tool_providers.registry import resolve_task_tools
+
+            tools = resolve_task_tools(spec, "ask")
+            result = _invoke_with_tools(
+                "system", "user", tools, {"engine": "openai", "model": "gpt-4o"}, "ask"
+            )
+
+        assert result == '{"answer": "direct"}'
+        mock_provider.invoke_with_tools.assert_called_once()
+
+    def test_one_tool_call_then_final(self, monkeypatch):
+        """Provider requests one tool call, gets result, then returns final answer."""
+        monkeypatch.setenv("MY_TEST_ENV", "42")
+        spec = self._make_spec()
+
+        tool_call = ToolCall(id="call_1", name="env_read", arguments={"name": "MY_TEST_ENV"})
+        turn1 = InvokeResult(is_final=False, tool_calls=[tool_call])
+        turn2 = InvokeResult(is_final=True, text='{"answer": "42"}')
+
+        mock_provider = MagicMock()
+        mock_provider.supports_tools.return_value = True
+        mock_provider.invoke_with_tools.side_effect = [turn1, turn2]
+
+        with patch("oas_cli.runner.get_provider", return_value=mock_provider):
+            from oas_cli.runner import _invoke_with_tools
+            from oas_cli.tool_providers.registry import resolve_task_tools
+
+            tools = resolve_task_tools(spec, "ask")
+            result = _invoke_with_tools(
+                "system", "user", tools, {"engine": "openai", "model": "gpt-4o"}, "ask"
+            )
+
+        assert result == '{"answer": "42"}'
+        assert mock_provider.invoke_with_tools.call_count == 2
+        # Verify the tool result was injected into the second call's messages
+        second_call_messages = mock_provider.invoke_with_tools.call_args_list[1][1]["messages"]
+        tool_msg = next(m for m in second_call_messages if m.get("role") == "tool")
+        assert tool_msg["content"] == "42"
+
+    def test_fallback_for_non_tool_providers(self):
+        """Providers that don't support tools get an augmented system prompt instead."""
+        spec = self._make_spec()
+
+        mock_provider = MagicMock()
+        mock_provider.supports_tools.return_value = False
+
+        with patch("oas_cli.runner.get_provider", return_value=mock_provider), \
+             patch("oas_cli.runner.invoke_intelligence", return_value='{"answer":"ok"}') as mock_invoke:
+            from oas_cli.runner import _invoke_with_tools
+            from oas_cli.tool_providers.registry import resolve_task_tools
+
+            tools = resolve_task_tools(spec, "ask")
+            result = _invoke_with_tools(
+                "You are helpful.", "user", tools, {"engine": "codex", "model": "x"}, "ask"
+            )
+
+        mock_invoke.assert_called_once()
+        call_system = mock_invoke.call_args[0][0]
+        assert "env_read" in call_system
+
+    def test_loop_cap_raises_run_error(self):
+        """Loop exits with OARunError after _MAX_TOOL_ITERATIONS."""
+        from oas_cli.runner import OARunError, _MAX_TOOL_ITERATIONS
+
+        spec = self._make_spec()
+        tool_call = ToolCall(id="call_1", name="env_read", arguments={"name": "X"})
+        never_final = InvokeResult(is_final=False, tool_calls=[tool_call])
+
+        mock_provider = MagicMock()
+        mock_provider.supports_tools.return_value = True
+        mock_provider.invoke_with_tools.return_value = never_final
+
+        with patch("oas_cli.runner.get_provider", return_value=mock_provider):
+            from oas_cli.runner import _invoke_with_tools
+            from oas_cli.tool_providers.registry import resolve_task_tools
+
+            tools = resolve_task_tools(spec, "ask")
+            with pytest.raises(OARunError, match="exceeded"):
+                _invoke_with_tools(
+                    "system", "user", tools, {"engine": "openai", "model": "gpt-4o"}, "ask"
+                )
+
+        assert mock_provider.invoke_with_tools.call_count == _MAX_TOOL_ITERATIONS
+
+
+# ── MCPToolProvider ───────────────────────────────────────────────────────────
+
+
+def _mock_urlopen(responses: list[dict]):
+    """Return a context manager mock that yields JSON responses in order."""
+    import io
+
+    call_count = {"n": 0}
+
+    class _Resp:
+        def __init__(self, data):
+            self._data = json.dumps(data).encode()
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            pass
+
+    def _urlopen(req, timeout=30):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return _Resp(responses[idx])
+
+    return _urlopen
+
+
+_LIST_RESPONSE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "tools": [
+            {
+                "name": "search_web",
+                "description": "Search the web for information.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "get_weather",
+                "description": "Get current weather for a location.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            },
+        ]
+    },
+}
+
+_CALL_RESPONSE = {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "result": {
+        "content": [
+            {"type": "text", "text": "Paris is sunny and 22°C."}
+        ]
+    },
+}
+
+
+class TestMCPToolProvider:
+    def _provider(self, **extra):
+        from oas_cli.tool_providers.mcp import MCPToolProvider
+
+        config = {"type": "mcp", "endpoint": "http://localhost:3000", **extra}
+        return MCPToolProvider(tool_name="my_mcp", tool_config=config)
+
+    # ── construction ───────────────────────────────────────────────────────
+
+    def test_missing_endpoint_raises(self):
+        from oas_cli.tool_providers.mcp import MCPToolProvider
+
+        with pytest.raises(ToolError, match="endpoint"):
+            MCPToolProvider(tool_name="x", tool_config={"type": "mcp"})
+
+    # ── describe / tools/list ──────────────────────────────────────────────
+
+    def test_describe_calls_tools_list(self):
+        p = self._provider()
+        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+            defs = p.describe()
+
+        assert len(defs) == 2
+        names = {d.name for d in defs}
+        assert "search_web" in names
+        assert "get_weather" in names
+
+    def test_describe_is_cached(self):
+        p = self._provider()
+        urlopen_mock = MagicMock(side_effect=_mock_urlopen([_LIST_RESPONSE]))
+        with patch("urllib.request.urlopen", urlopen_mock):
+            p.describe()
+            p.describe()
+
+        # Only one HTTP call despite two describe() calls
+        assert urlopen_mock.call_count == 1
+
+    def test_describe_parses_input_schema(self):
+        p = self._provider()
+        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+            defs = p.describe()
+
+        search = next(d for d in defs if d.name == "search_web")
+        assert "query" in search.parameters["properties"]
+
+    def test_empty_tools_list_raises(self):
+        p = self._provider()
+        empty_response = {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([empty_response])):
+            with pytest.raises(ToolError, match="no tools"):
+                p.describe()
+
+    # ── call / tools/call ──────────────────────────────────────────────────
+
+    def test_call_success(self):
+        p = self._provider()
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_mock_urlopen([_LIST_RESPONSE, _CALL_RESPONSE]),
+        ):
+            result = p.call("get_weather", {"location": "Paris"})
+
+        assert result == "Paris is sunny and 22°C."
+
+    def test_call_unknown_tool_raises(self):
+        p = self._provider()
+        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+            with pytest.raises(ToolNotFoundError, match="magic_wand"):
+                p.call("magic_wand", {})
+
+    def test_call_sends_correct_jsonrpc_payload(self):
+        p = self._provider()
+        captured = {}
+
+        def _capture(req, timeout=30):
+            captured["body"] = json.loads(req.data.decode())
+
+            class _R:
+                def read(self):
+                    return json.dumps(_CALL_RESPONSE).encode()
+                def __enter__(self): return self
+                def __exit__(self, *_): pass
+
+            return _R()
+
+        # First call discovers tools, second executes
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=[_mock_urlopen([_LIST_RESPONSE])("_"), _capture],
+        ):
+            # Seed the cache so only one HTTP round-trip happens
+            with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+                p.describe()
+            with patch("urllib.request.urlopen", _capture):
+                p.call("get_weather", {"location": "Paris"})
+
+        assert captured["body"]["method"] == "tools/call"
+        assert captured["body"]["params"]["name"] == "get_weather"
+        assert captured["body"]["params"]["arguments"] == {"location": "Paris"}
+
+    # ── result normalisation ───────────────────────────────────────────────
+
+    def test_extract_bare_string(self):
+        from oas_cli.tool_providers.mcp import _extract_call_result
+
+        assert _extract_call_result("hello", "t", "http://x") == "hello"
+
+    def test_extract_content_block_list(self):
+        from oas_cli.tool_providers.mcp import _extract_call_result
+
+        result = {"content": [{"type": "text", "text": "foo"}, {"type": "text", "text": "bar"}]}
+        assert _extract_call_result(result, "t", "http://x") == "foo\nbar"
+
+    def test_extract_content_string(self):
+        from oas_cli.tool_providers.mcp import _extract_call_result
+
+        assert _extract_call_result({"content": "direct"}, "t", "http://x") == "direct"
+
+    def test_extract_result_key(self):
+        from oas_cli.tool_providers.mcp import _extract_call_result
+
+        assert _extract_call_result({"result": 42}, "t", "http://x") == "42"
+
+    def test_extract_none_returns_empty(self):
+        from oas_cli.tool_providers.mcp import _extract_call_result
+
+        assert _extract_call_result(None, "t", "http://x") == ""
+
+    # ── env-var header expansion ───────────────────────────────────────────
+
+    def test_env_var_expanded_in_headers(self, monkeypatch):
+        monkeypatch.setenv("MY_MCP_KEY", "secret-token")
+        p = self._provider(headers={"X-API-Key": "${MY_MCP_KEY}"})
+
+        captured_headers = {}
+
+        def _capture(req, timeout=30):
+            captured_headers.update(dict(req.headers))
+
+            class _R:
+                def read(self):
+                    return json.dumps(_LIST_RESPONSE).encode()
+                def __enter__(self): return self
+                def __exit__(self, *_): pass
+
+            return _R()
+
+        with patch("urllib.request.urlopen", _capture):
+            p.describe()
+
+        # urllib title-cases header names
+        assert captured_headers.get("X-api-key") == "secret-token"
+
+    def test_missing_env_var_warns(self, monkeypatch):
+        import warnings
+
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # env-var expansion happens at construction time inside _resolve_headers
+            self._provider(headers={"X-Token": "${MISSING_VAR}"})
+
+        assert any("MISSING_VAR" in str(warning.message) for warning in w)
+
+    # ── HTTP error handling ────────────────────────────────────────────────
+
+    def test_http_error_raises_tool_error(self):
+        import urllib.error
+
+        p = self._provider()
+        err = urllib.error.HTTPError(
+            "http://localhost:3000", 500, "Internal Server Error", {}, None
+        )
+        # HTTPError.read() is not available without a real response; mock it
+        err.read = lambda: b"server exploded"
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(ToolError, match="MCP HTTP 500"):
+                p.describe()
+
+    def test_json_rpc_error_raises_tool_error(self):
+        p = self._provider()
+        error_response = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32601, "message": "Method not found"},
+        }
+        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([error_response])):
+            with pytest.raises(ToolError, match="Method not found"):
+                p.describe()
+
+    # ── registry integration ───────────────────────────────────────────────
+
+    def test_registry_routes_mcp_type(self):
+        from oas_cli.tool_providers.mcp import MCPToolProvider
+
+        p = get_tool_provider(
+            "my_server",
+            {"type": "mcp", "endpoint": "http://localhost:3000"},
+        )
+        assert isinstance(p, MCPToolProvider)
+
+    def test_to_openai_schema_shape(self):
+        p = self._provider()
+        with patch("urllib.request.urlopen", side_effect=_mock_urlopen([_LIST_RESPONSE])):
+            defs = p.describe()
+
+        schema = defs[0].to_openai_schema()
+        assert schema["type"] == "function"
+        assert "name" in schema["function"]
+        assert "parameters" in schema["function"]
+
+    # ── validator ─────────────────────────────────────────────────────────
+
+    def test_validator_accepts_mcp_tool(self):
+        from oas_cli.validators import validate_spec
+
+        spec = {
+            "open_agent_spec": "1.0",
+            "agent": {"name": "test", "role": "test"},
+            "tools": {
+                "my_mcp": {
+                    "type": "mcp",
+                    "endpoint": "http://localhost:3000",
+                    "description": "A remote MCP server",
+                }
+            },
+            "tasks": {
+                "task1": {
+                    "tools": ["my_mcp"],
+                    "input": {"query": {"type": "string"}},
+                    "output": {"result": {"type": "string"}},
+                }
+            },
+            "prompts": {"system": "test", "user": "test"},
+        }
+        validate_spec(spec)  # must not raise
+
+    def test_validator_rejects_mcp_without_endpoint(self):
+        from oas_cli.validators import validate_spec
+
+        spec = {
+            "open_agent_spec": "1.0",
+            "agent": {"name": "test", "role": "test"},
+            "tools": {"my_mcp": {"type": "mcp"}},
+            "tasks": {
+                "task1": {
+                    "input": {"q": {"type": "string"}},
+                    "output": {"r": {"type": "string"}},
+                }
+            },
+            "prompts": {"system": "test", "user": "test"},
+        }
+        with pytest.raises(ValueError, match="endpoint"):
+            validate_spec(spec)

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -17,7 +17,7 @@ def _valid_spec(**overrides):
     spec = {
         "open_agent_spec": "1.0",
         "agent": {"name": "test", "role": "test"},
-        "tools": [],
+        "tools": {},
         "tasks": {
             "task1": {
                 "input": {"query": {"type": "string"}},
@@ -109,41 +109,38 @@ class TestBehaviouralContractErrors:
 
 class TestToolErrors:
     def test_tools_wrong_type(self):
-        spec = _valid_spec(tools="not a list")
-        with pytest.raises(ValueError, match=r"list.*got str"):
+        spec = _valid_spec(tools="not a dict")
+        with pytest.raises(ValueError, match=r"dictionary.*got str"):
             validate_spec(spec)
 
-    def test_tool_item_wrong_type(self):
-        spec = _valid_spec(tools=["not a dict"])
-        with pytest.raises(ValueError, match=r"tools\[0\]"):
+    def test_tool_declaration_wrong_type(self):
+        spec = _valid_spec(tools={"my_tool": "not a dict"})
+        with pytest.raises(ValueError, match=r"tools\.my_tool.*object"):
             validate_spec(spec)
 
-    def test_tool_id_wrong_type_shows_index(self):
-        spec = _valid_spec(
-            tools=[
-                {
-                    "id": "good",
-                    "type": "function",
-                    "description": "ok",
-                },
-                {
-                    "id": 123,
-                    "type": "function",
-                    "description": "bad",
-                },
-            ]
-        )
-        with pytest.raises(ValueError, match=r"tools\[1\]\.id.*int"):
+    def test_tool_missing_type_field(self):
+        spec = _valid_spec(tools={"my_tool": {"description": "does something"}})
+        with pytest.raises(ValueError, match=r"tools\.my_tool\.type"):
             validate_spec(spec)
 
-    def test_tool_missing_description(self):
-        spec = _valid_spec(tools=[{"id": "t1", "type": "function"}])
-        with pytest.raises(ValueError, match=r"tools\[0\]\.description.*missing"):
+    def test_tool_unsupported_type(self):
+        spec = _valid_spec(tools={"my_tool": {"type": "webhook"}})
+        with pytest.raises(ValueError, match=r"tools\.my_tool\.type"):
             validate_spec(spec)
 
-    def test_tool_missing_type(self):
-        spec = _valid_spec(tools=[{"id": "t1", "description": "desc"}])
-        with pytest.raises(ValueError, match=r"tools\[0\]\.type.*missing"):
+    def test_native_tool_missing_native_field(self):
+        spec = _valid_spec(tools={"my_tool": {"type": "native"}})
+        with pytest.raises(ValueError, match=r"'native' field"):
+            validate_spec(spec)
+
+    def test_native_tool_unknown_id(self):
+        spec = _valid_spec(tools={"my_tool": {"type": "native", "native": "magic.wand"}})
+        with pytest.raises(ValueError, match=r"magic\.wand.*not a recognised"):
+            validate_spec(spec)
+
+    def test_custom_tool_missing_module(self):
+        spec = _valid_spec(tools={"my_tool": {"type": "custom", "description": "x"}})
+        with pytest.raises(ValueError, match=r"'module' field"):
             validate_spec(spec)
 
 
@@ -163,21 +160,13 @@ class TestTaskErrors:
 
     def test_nonexistent_tool_lists_available(self):
         spec = _valid_spec(
-            tools=[
-                {
-                    "id": "tool1",
-                    "type": "function",
-                    "description": "T1",
-                },
-                {
-                    "id": "tool2",
-                    "type": "function",
-                    "description": "T2",
-                },
-            ],
+            tools={
+                "tool1": {"type": "native", "native": "file.read"},
+                "tool2": {"type": "native", "native": "env.read"},
+            },
             tasks={
                 "bad_task": {
-                    "tool": "nonexistent",
+                    "tools": ["nonexistent"],
                     "input": {},
                     "output": {},
                 }

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -134,7 +134,9 @@ class TestToolErrors:
             validate_spec(spec)
 
     def test_native_tool_unknown_id(self):
-        spec = _valid_spec(tools={"my_tool": {"type": "native", "native": "magic.wand"}})
+        spec = _valid_spec(
+            tools={"my_tool": {"type": "native", "native": "magic.wand"}}
+        )
         with pytest.raises(ValueError, match=r"magic\.wand.*not a recognised"):
             validate_spec(spec)
 


### PR DESCRIPTION
Introduces a full tool provider layer so OAS tasks can call external tools during model execution, with a clean multi-turn loop and no new dependencies.

Tool provider package (oas_cli/tool_providers/):
- ToolProvider ABC with ToolDefinition, ToolCall, InvokeResult types
- NativeToolProvider: file.read, file.write, http.get, http.post, env.read
- MCPToolProvider: connects to any MCP server via JSON-RPC 2.0 over raw HTTP (tools/list for discovery, tools/call for execution, ${ENV_VAR} header expansion)
- CustomToolProvider: dynamically loads user-defined Python classes
- Registry: resolve_task_tools, dispatch_tool_call, get_tool_provider

Provider updates:
- OpenAIProvider and AnthropicProvider implement invoke_with_tools() for native function calling; other providers fall back to text-described tools

Runner updates:
- _invoke_with_tools() multi-turn loop (max 10 iterations, cap raises OARunError)
- Single-brace {key} template substitution added alongside existing {{ key }}

Schema + validator:
- Top-level tools: block (type: native | mcp | custom) with per-field validation
- Per-task tools: list referencing declared tool names
- prompts: block made optional (per-task prompts are sufficient)

Examples:
- examples/file-reader/  native file.read tool, summarises any file
- examples/mcp-local/    self-contained local MCP server (pure Python stdlib)
- examples/mcp-search/   template for Brave Search / any hosted MCP server

52 new tests, 321 passing total.

Made-with: Cursor

## What changed

<!-- 1-3 sentences: what does this PR do? -->

## Why

<!-- Link to issue or explain the motivation -->

## How tested

<!-- Commands you ran, tests you wrote, or manual checks -->

- [ ] All existing tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring / CI / tooling

## Breaking changes

<!-- If none, delete this section. Otherwise list what breaks and migration steps. -->

## Checklist

- [ ] Code follows project style (`ruff check . && ruff format --check .`)
- [ ] Self-review completed
- [ ] Version bumped if needed (`pyproject.toml`, templates, docs)
