### PR TITLE
feat: spec composition via task delegation

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -229,7 +229,33 @@ Omit `expect` or use `{}` for a **smoke** case that only checks the task complet
 
 ---
 
-## depends_on — linear task chaining
+## depends_on — data dependencies between tasks
+
+### Design principle
+
+> **OAS describes what data a task needs and how it is implemented —
+> never how execution should proceed.**
+
+`depends_on` is a **data contract**, not a workflow instruction.
+When a task declares `depends_on: [extract]`, it is saying:
+
+> "I require `extract`'s output fields as part of my input."
+
+Execution ordering is a *side-effect* of satisfying that data dependency — not the purpose.
+
+This distinction matters. OAS intentionally **does not support** and will not add:
+
+| Feature | Why it's out of scope |
+|---|---|
+| Branching / conditionals | Execution control — belongs in the calling platform |
+| Loops / retries | Runtime policy — belongs in the calling platform |
+| Parallel execution | Scheduling — belongs in the calling platform |
+| Fallback tasks | Dynamic routing — belongs in the calling platform |
+| Dynamic task selection | Orchestration — belongs in the calling platform |
+
+If you need any of the above, express them outside OAS in whatever platform or orchestrator is invoking the spec. OAS stays composable and inspectable precisely because it refuses to become a workflow engine.
+
+---
 
 A task can declare that it needs the output of another task before it can run:
 
@@ -265,14 +291,13 @@ tasks:
 
 ### Execution rules
 
-1. **Dependencies run first**, in the order listed in `depends_on`
-2. **Output is merged into input** — previous task output wins on key collision:
+1. **Outputs are merged into input** — declared dependencies run first so their data is available:
    ```
    merged = {**caller_input, **dep1_output, **dep2_output, ...}
    ```
-3. **Fail fast** — required input fields are validated *after* the merge; missing fields raise `CHAIN_INPUT_MISSING` before the model is called
-4. **Linear chains only** — no branching, no conditions, no loops
-5. **Cycle detection** — circular references raise `CHAIN_CYCLE_ERROR` at run time
+2. **Fail fast** — required input fields are validated *after* the merge; missing fields raise `CHAIN_INPUT_MISSING` before the model is called
+3. **Linear chains only** — no branching, no conditions, no loops; if you need those, express them outside OAS
+4. **Cycle detection** — circular references raise `CHAIN_CYCLE_ERROR` at run time
 
 ### Result envelope
 

--- a/examples/spec-composition/coordinator.yaml
+++ b/examples/spec-composition/coordinator.yaml
@@ -1,0 +1,61 @@
+open_agent_spec: "1.3.0"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Spec Composition demo — coordinator.yaml
+#
+# This spec does NOT implement any task logic itself.
+# Each task delegates to a shared specialist spec via `spec:` + `task:`.
+#
+# Run with:
+#   oa run --spec examples/spec-composition/coordinator.yaml \
+#           --task analyse_sentiment \
+#           --input '{"text": "OA spec composition is surprisingly elegant."}'
+#
+#   oa run --spec examples/spec-composition/coordinator.yaml \
+#           --task summarise \
+#           --input '{"text": "Open Agent Spec lets you build multi-task agents
+#                               directly from YAML with no framework required."}'
+# ─────────────────────────────────────────────────────────────────────────────
+
+agent:
+  name: content-analyser
+  description: >
+    A multi-capability content agent that delegates specialist work to
+    shared, reusable specs. Demonstrates OA spec composition — zero
+    duplication, maximum reuse.
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.2
+
+# ── Tasks ────────────────────────────────────────────────────────────────────
+# Every task here is a thin delegation pointer. No prompts, no output schema —
+# all of that lives in the shared specialists.
+
+tasks:
+  summarise:
+    description: >
+      Summarise a body of text. Delegates to shared/summariser.yaml.
+    spec: ./shared/summariser.yaml
+    task: summarise
+
+  analyse_sentiment:
+    description: >
+      Analyse the sentiment of a body of text. Delegates to shared/sentiment.yaml.
+    spec: ./shared/sentiment.yaml
+    task: analyse_sentiment
+
+  sentiment_of_summary:
+    description: >
+      Analyse the sentiment of a summarised text. Requires the output of
+      'summarise' as its input — this is a data dependency, not a workflow
+      instruction. OAS merges the summary output into this task's input;
+      execution ordering is a side-effect of that, not the purpose.
+    depends_on:
+      - summarise
+    spec: ./shared/sentiment.yaml
+    task: analyse_sentiment

--- a/examples/spec-composition/run.sh
+++ b/examples/spec-composition/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Spec Composition demo — three tasks, two shared specialists, zero duplication.
+set -euo pipefail
+
+SPEC="examples/spec-composition/coordinator.yaml"
+TEXT="Open Agent Spec lets you write multi-step agents as plain YAML. \
+Tasks can delegate to shared specialist specs, so you build modular \
+pipelines without a framework — just composable, reusable logic."
+
+echo "═══════════════════════════════════════════════════════════"
+echo " OA Spec Composition Demo"
+echo "═══════════════════════════════════════════════════════════"
+echo ""
+
+echo "── Task 1: summarise (delegates to shared/summariser.yaml) ──"
+oa run --spec "$SPEC" --task summarise \
+       --input "{\"text\": \"$TEXT\"}"
+
+echo ""
+echo "── Task 2: analyse_sentiment (delegates to shared/sentiment.yaml) ──"
+oa run --spec "$SPEC" --task analyse_sentiment \
+       --input "{\"text\": \"$TEXT\"}"
+
+echo ""
+echo "── Task 3: sentiment_of_summary (data dep on summarise → sentiment, both delegated) ──"
+oa run --spec "$SPEC" --task sentiment_of_summary \
+       --input "{\"text\": \"$TEXT\"}"

--- a/examples/spec-composition/shared/sentiment.yaml
+++ b/examples/spec-composition/shared/sentiment.yaml
@@ -1,0 +1,60 @@
+open_agent_spec: "1.3.0"
+
+agent:
+  name: shared-sentiment
+  description: >
+    Reusable sentiment analyser. Called by coordinator specs via
+    spec delegation — not intended to be run directly.
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.1
+
+tasks:
+  analyse_sentiment:
+    description: Determine the overall sentiment of a piece of text.
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to analyse.
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        sentiment:
+          type: string
+          description: "One of: positive, negative, neutral, mixed"
+        confidence:
+          type: number
+          description: Confidence score between 0 and 1.
+        reasoning:
+          type: string
+          description: Brief explanation of the sentiment verdict.
+      required:
+        - sentiment
+        - confidence
+        - reasoning
+    prompts:
+      system: >
+        You are a precise sentiment analysis engine. Classify the sentiment of
+        the provided text as positive, negative, neutral, or mixed.
+        Always respond with valid JSON.
+      user: |
+        Analyse the sentiment of the following text.
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "sentiment": "positive|negative|neutral|mixed",
+          "confidence": 0.0-1.0,
+          "reasoning": "<brief explanation>"
+        }

--- a/examples/spec-composition/shared/summariser.yaml
+++ b/examples/spec-composition/shared/summariser.yaml
@@ -1,0 +1,56 @@
+open_agent_spec: "1.3.0"
+
+agent:
+  name: shared-summariser
+  description: >
+    Reusable summarisation specialist. Called by coordinator specs via
+    spec delegation — not intended to be run directly.
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.2
+
+tasks:
+  summarise:
+    description: Summarise a body of text concisely.
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to summarise.
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        summary:
+          type: string
+          description: A short, clear summary of the text.
+        key_points:
+          type: array
+          items:
+            type: string
+          description: Up to five key points extracted from the text.
+      required:
+        - summary
+        - key_points
+    prompts:
+      system: >
+        You are a concise technical writer. Summarise clearly and extract the
+        most important points. Always respond with valid JSON.
+      user: |
+        Summarise the following text and extract key points.
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "summary": "<one or two sentences>",
+          "key_points": ["point 1", "point 2", ...]
+        }

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -97,7 +97,7 @@ class OpenAIProvider(IntelligenceProvider):
         max_tokens = int(config.get("max_tokens", 1000))
         timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
 
-        all_messages = [{"role": "system", "content": system}] + messages
+        all_messages = [{"role": "system", "content": system}, *messages]
         payload: dict[str, Any] = {
             "model": model,
             "messages": all_messages,

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -241,6 +241,9 @@ def _resolve_chain(
     base_input: dict[str, Any],
     override_system: str | None,
     override_user: str | None,
+    *,
+    spec_path: Path | None = None,
+    _visited_specs: frozenset[Path] = frozenset(),
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Resolve depends_on chain and return (merged_input, chain_results).
 
@@ -289,6 +292,8 @@ def _resolve_chain(
             dict(merged),
             override_system=None,
             override_user=None,
+            spec_path=spec_path,
+            _visited_specs=_visited_specs,
         )
         chain[dep_name] = dep_result
         dep_output = dep_result.get("output") or {}
@@ -449,10 +454,87 @@ def _run_single_task(
     input_data: dict[str, Any],
     override_system: str | None,
     override_user: str | None,
+    *,
+    spec_path: Path | None = None,
+    _visited_specs: frozenset[Path] = frozenset(),
 ) -> dict[str, Any]:
-    """Execute one task (no chain resolution) and return the result envelope."""
+    """Execute one task (no chain resolution) and return the result envelope.
+
+    If the task declares ``spec:`` + ``task:`` it is a *delegated* task — the
+    runner loads the referenced spec and executes that task transparently,
+    returning the result as if it had been defined inline.
+    """
     tasks = spec_data.get("tasks") or {}
     task_def = tasks.get(task_name) or {}
+
+    # ── Spec delegation ───────────────────────────────────────────────────
+    delegation_spec_ref: str | None = task_def.get("spec")
+    if delegation_spec_ref is not None:
+        if not isinstance(delegation_spec_ref, str) or not delegation_spec_ref.strip():
+            raise OARunError(
+                f"Task '{task_name}': 'spec' must be a non-empty string path",
+                code="SPEC_LOAD_ERROR",
+                stage="delegation",
+                task=task_name,
+            )
+
+        # Resolve path relative to the calling spec's directory.
+        ref = Path(delegation_spec_ref.strip())
+        if not ref.is_absolute() and spec_path is not None:
+            ref = (spec_path.parent / ref).resolve()
+        else:
+            ref = ref.resolve()
+
+        # Cycle guard — prevent A → B → A loops.
+        canonical = ref
+        if canonical in _visited_specs:
+            raise OARunError(
+                f"Circular spec delegation detected: '{canonical}' is already in "
+                "the delegation stack",
+                code="DELEGATION_CYCLE_ERROR",
+                stage="delegation",
+                task=task_name,
+            )
+
+        delegated_spec = _load_spec(canonical)
+        new_visited = _visited_specs | {canonical}
+
+        # Use the explicitly named task, or fall back to same name as the caller.
+        delegated_task: str = task_def.get("task") or task_name
+
+        # Validate the task exists in the referenced spec before going further.
+        delegated_tasks = delegated_spec.get("tasks") or {}
+        if delegated_task not in delegated_tasks:
+            available = ", ".join(f"'{t}'" for t in delegated_tasks) or "none"
+            raise OARunError(
+                f"Task '{delegated_task}' not found in delegated spec '{canonical}'. "
+                f"Available tasks: {available}",
+                code="TASK_NOT_FOUND",
+                stage="delegation",
+                task=task_name,
+            )
+
+        logger.debug(
+            "[delegation] task '%s' → %s#%s",
+            task_name,
+            canonical,
+            delegated_task,
+        )
+
+        result = _run_single_task(
+            delegated_spec,
+            delegated_task,
+            input_data,
+            override_system,
+            override_user,
+            spec_path=canonical,
+            _visited_specs=new_visited,
+        )
+        # Surface the coordinator's task name so the envelope is consistent
+        # from the caller's perspective.
+        result["task"] = task_name
+        result["delegated_to"] = f"{canonical}#{delegated_task}"
+        return result
 
     # Validate required inputs before touching the model.
     inp_schema = task_def.get("input") or {}
@@ -569,6 +651,8 @@ def run_task_from_spec(
     input_data: dict[str, Any] | None = None,
     override_system: str | None = None,
     override_user: str | None = None,
+    *,
+    spec_path: Path | None = None,
 ) -> dict[str, Any]:
     """Run a task defined in the spec, resolving any depends_on chain first.
 
@@ -577,12 +661,25 @@ def run_task_from_spec(
 
     override_system / override_user replace the resolved spec prompt for this
     invocation only — useful for targeted one-off instructions from the CLI.
+
+    spec_path is used to resolve relative ``spec:`` delegation references.
     """
     base_input: dict[str, Any] = dict(input_data or {})
     chosen_task, _ = _choose_task(spec_data, task_name)
 
+    # Seed the visited set with the calling spec so direct self-delegation is caught.
+    visited: frozenset[Path] = frozenset()
+    if spec_path is not None:
+        visited = frozenset({spec_path.resolve()})
+
     merged_input, chain = _resolve_chain(
-        spec_data, chosen_task, base_input, override_system, override_user
+        spec_data,
+        chosen_task,
+        base_input,
+        override_system,
+        override_user,
+        spec_path=spec_path,
+        _visited_specs=visited,
     )
 
     result = _run_single_task(
@@ -591,6 +688,8 @@ def run_task_from_spec(
         merged_input,
         override_system=override_system,
         override_user=override_user,
+        spec_path=spec_path,
+        _visited_specs=visited,
     )
 
     if chain:
@@ -607,11 +706,13 @@ def run_task_from_file(
     override_user: str | None = None,
 ) -> dict[str, Any]:
     """Convenience wrapper to load a spec from disk and run a task."""
-    spec = _load_spec(spec_path)
+    resolved = spec_path.resolve()
+    spec = _load_spec(resolved)
     return run_task_from_spec(
         spec,
         task_name=task_name,
         input_data=input_data,
         override_system=override_system,
         override_user=override_user,
+        spec_path=resolved,
     )

--- a/oas_cli/schemas/oas-schema.json
+++ b/oas_cli/schemas/oas-schema.json
@@ -356,7 +356,7 @@
               "items": {
                 "type": "string"
               },
-              "description": "List of task names that must run before this task. Their outputs are merged into this task's input (later entries win on key collision). Linear chains only \u2014 no branching or conditions."
+              "description": "Declares data dependencies: the named tasks must produce output before this task can run, and their outputs are merged into this task's input (later entries win on key collision). IMPORTANT \u2014 this is a data contract, not execution control. OAS intentionally prohibits: branching, conditionals, loops, retries, fallbacks, parallel execution, and dynamic task selection. If you need any of those, they belong outside OAS in the calling platform. Linear chains only."
             },
             "behavioural_contract": {
               "type": "object",
@@ -368,11 +368,18 @@
                 "type": "string"
               },
               "description": "Names of tools from the top-level tools: block that this task is allowed to use."
+            },
+            "spec": {
+              "type": "string",
+              "description": "Path to another spec YAML file whose task implements this task. Relative paths are resolved from the directory of the calling spec. When present, this task is delegated \u2014 inline prompts and output schema are ignored in favour of the referenced spec's task definition."
+            },
+            "task": {
+              "type": "string",
+              "description": "Name of the task to run in the referenced spec (used with 'spec:'). Defaults to the same name as this task when omitted."
             }
           },
           "required": [
-            "description",
-            "output"
+            "description"
           ]
         }
       },

--- a/oas_cli/validators.py
+++ b/oas_cli/validators.py
@@ -249,6 +249,22 @@ def _validate_tasks(spec_data: dict) -> None:
                         "Check your top-level 'tools:' section."
                     )
 
+        # Check spec delegation fields
+        if "spec" in task_def:
+            spec_ref = task_def["spec"]
+            if not isinstance(spec_ref, str) or not spec_ref.strip():
+                raise ValueError(
+                    f"tasks.{task_name}.spec must be a non-empty string path, "
+                    f"got {type(spec_ref).__name__!r}."
+                )
+            if "task" in task_def and not isinstance(task_def["task"], str):
+                raise ValueError(
+                    f"tasks.{task_name}.task must be a string (the task name in "
+                    f"the referenced spec), got {type(task_def['task']).__name__!r}."
+                )
+            # Delegated tasks don't require inline input/output schemas.
+            continue
+
         # Check if this is a multi-step task
         is_multi_step = task_def.get("multi_step", False)
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -266,7 +266,7 @@ class TestCustomProvider:
 
     def test_missing_dot_in_module_path_raises(self):
         provider = CustomProvider()
-        with pytest.raises(ProviderError, match="module.ClassName"):
+        with pytest.raises(ProviderError, match=r"module\.ClassName"):
             provider.invoke(system="s", user="u", config={"module": "NoDotsHere"})
 
     def test_class_not_found_raises(self, tmp_path, monkeypatch):

--- a/tests/test_spec_composition.py
+++ b/tests/test_spec_composition.py
@@ -53,8 +53,16 @@ class TestBasicDelegation:
             tasks={
                 "greet": {
                     "description": "Say hello",
-                    "input": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
-                    "output": {"type": "object", "properties": {"reply": {"type": "string"}}, "required": ["reply"]},
+                    "input": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    },
+                    "output": {
+                        "type": "object",
+                        "properties": {"reply": {"type": "string"}},
+                        "required": ["reply"],
+                    },
                     "prompts": {"system": "Greet the user.", "user": "Hello {name}"},
                 }
             }
@@ -76,7 +84,9 @@ class TestBasicDelegation:
             return json.dumps({"reply": "Hello there!"})
 
         with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
-            result = run_task_from_file(coordinator_path, task_name="greet", input_data={"name": "Alice"})
+            result = run_task_from_file(
+                coordinator_path, task_name="greet", input_data={"name": "Alice"}
+            )
 
         assert result["task"] == "greet"
         assert result["output"]["reply"] == "Hello there!"
@@ -89,7 +99,11 @@ class TestBasicDelegation:
                 "analyse": {
                     "description": "Analyse",
                     "input": {"type": "object", "properties": {}, "required": []},
-                    "output": {"type": "object", "properties": {"result": {"type": "string"}}, "required": ["result"]},
+                    "output": {
+                        "type": "object",
+                        "properties": {"result": {"type": "string"}},
+                        "required": ["result"],
+                    },
                     "prompts": {"system": "Analyse.", "user": "Go"},
                 }
             }
@@ -123,7 +137,11 @@ class TestBasicDelegation:
                 "internal_summarise": {
                     "description": "Internal summariser",
                     "input": {"type": "object", "properties": {}, "required": []},
-                    "output": {"type": "object", "properties": {"summary": {"type": "string"}}, "required": ["summary"]},
+                    "output": {
+                        "type": "object",
+                        "properties": {"summary": {"type": "string"}},
+                        "required": ["summary"],
+                    },
                     "prompts": {"system": "Summarise.", "user": "Go"},
                 }
             }
@@ -141,7 +159,10 @@ class TestBasicDelegation:
         _write_spec(tmp_path, "shared.yaml", shared_spec)
         coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
 
-        with patch("oas_cli.runner.invoke_intelligence", lambda s, u, c: json.dumps({"summary": "brief"})):
+        with patch(
+            "oas_cli.runner.invoke_intelligence",
+            lambda s, u, c: json.dumps({"summary": "brief"}),
+        ):
             result = run_task_from_file(coordinator_path, task_name="summarise")
 
         assert result["task"] == "summarise"
@@ -157,8 +178,18 @@ class TestDelegationWithChain:
             tasks={
                 "extract": {
                     "description": "Extract keywords",
-                    "input": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
-                    "output": {"type": "object", "properties": {"keywords": {"type": "array", "items": {"type": "string"}}}, "required": ["keywords"]},
+                    "input": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                        "required": ["text"],
+                    },
+                    "output": {
+                        "type": "object",
+                        "properties": {
+                            "keywords": {"type": "array", "items": {"type": "string"}}
+                        },
+                        "required": ["keywords"],
+                    },
                     "prompts": {"system": "Extract.", "user": "Extract from: {text}"},
                 }
             }
@@ -174,8 +205,16 @@ class TestDelegationWithChain:
                 "report": {
                     "description": "Build report from keywords",
                     "depends_on": ["extract"],
-                    "input": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
-                    "output": {"type": "object", "properties": {"report": {"type": "string"}}, "required": ["report"]},
+                    "input": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                        "required": ["text"],
+                    },
+                    "output": {
+                        "type": "object",
+                        "properties": {"report": {"type": "string"}},
+                        "required": ["report"],
+                    },
                     "prompts": {"system": "Report.", "user": "Report on keywords"},
                 },
             }
@@ -219,7 +258,7 @@ class TestCycleDetection:
             tasks={
                 "do_thing": {
                     "description": "Self-delegating",
-                    "spec": str(spec_path),   # absolute path to itself
+                    "spec": str(spec_path),  # absolute path to itself
                     "task": "do_thing",
                 }
             }
@@ -298,7 +337,11 @@ class TestDelegationErrors:
                 "real_task": {
                     "description": "exists",
                     "input": {"type": "object", "properties": {}, "required": []},
-                    "output": {"type": "object", "properties": {"r": {"type": "string"}}, "required": ["r"]},
+                    "output": {
+                        "type": "object",
+                        "properties": {"r": {"type": "string"}},
+                        "required": ["r"],
+                    },
                     "prompts": {"system": "s", "user": "u"},
                 }
             }
@@ -331,7 +374,11 @@ class TestDelegationErrors:
                 "ping": {
                     "description": "ping",
                     "input": {"type": "object", "properties": {}, "required": []},
-                    "output": {"type": "object", "properties": {"pong": {"type": "string"}}, "required": ["pong"]},
+                    "output": {
+                        "type": "object",
+                        "properties": {"pong": {"type": "string"}},
+                        "required": ["pong"],
+                    },
                     "prompts": {"system": "s", "user": "u"},
                 }
             }
@@ -349,7 +396,10 @@ class TestDelegationErrors:
         _write_spec(tmp_path / "shared", "pinger.yaml", shared_spec)
         coordinator_path = _write_spec(sub, "coordinator.yaml", coordinator_spec)
 
-        with patch("oas_cli.runner.invoke_intelligence", lambda s, u, c: json.dumps({"pong": "ok"})):
+        with patch(
+            "oas_cli.runner.invoke_intelligence",
+            lambda s, u, c: json.dumps({"pong": "ok"}),
+        ):
             result = run_task_from_file(coordinator_path, task_name="ping")
 
         assert result["output"]["pong"] == "ok"

--- a/tests/test_spec_composition.py
+++ b/tests/test_spec_composition.py
@@ -1,0 +1,418 @@
+"""Tests for spec delegation / composition.
+
+A task with ``spec: ./other.yaml`` + ``task: some_task`` delegates execution
+to that spec's task.  The delegation is transparent to depends_on chains and
+returns an envelope consistent with the coordinator's task name.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from oas_cli.runner import OARunError, run_task_from_file
+
+# ── Minimal spec helpers ──────────────────────────────────────────────────────
+
+_INTELLIGENCE = {
+    "type": "llm",
+    "engine": "openai",
+    "model": "gpt-4o-mini",
+}
+
+
+def _make_spec(tasks: dict, prompts: dict | None = None) -> dict:
+    return {
+        "open_agent_spec": "1.3.0",
+        "agent": {"name": "test", "description": "test", "role": "analyst"},
+        "intelligence": _INTELLIGENCE,
+        "tasks": tasks,
+        "prompts": prompts or {"system": "You are helpful.", "user": "Hello"},
+    }
+
+
+def _write_spec(tmp_path: Path, name: str, spec: dict) -> Path:
+    import yaml
+
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.dump(spec))
+    return p
+
+
+# ── Basic delegation ──────────────────────────────────────────────────────────
+
+
+class TestBasicDelegation:
+    def test_delegated_task_executes_referenced_spec(self, tmp_path):
+        """Coordinator delegates 'greet' to shared/greeter.yaml#greet."""
+        shared_spec = _make_spec(
+            tasks={
+                "greet": {
+                    "description": "Say hello",
+                    "input": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+                    "output": {"type": "object", "properties": {"reply": {"type": "string"}}, "required": ["reply"]},
+                    "prompts": {"system": "Greet the user.", "user": "Hello {name}"},
+                }
+            }
+        )
+        coordinator_spec = _make_spec(
+            tasks={
+                "greet": {
+                    "description": "Delegated greeter",
+                    "spec": "shared/greeter.yaml",
+                    "task": "greet",
+                }
+            }
+        )
+
+        _write_spec(tmp_path / "shared", "greeter.yaml", shared_spec)
+        coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
+
+        def fake_invoke(system, user, config):
+            return json.dumps({"reply": "Hello there!"})
+
+        with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
+            result = run_task_from_file(coordinator_path, task_name="greet", input_data={"name": "Alice"})
+
+        assert result["task"] == "greet"
+        assert result["output"]["reply"] == "Hello there!"
+        assert "delegated_to" in result
+
+    def test_delegation_task_name_defaults_to_caller(self, tmp_path):
+        """When 'task:' is omitted, uses the same name as the coordinator task."""
+        shared_spec = _make_spec(
+            tasks={
+                "analyse": {
+                    "description": "Analyse",
+                    "input": {"type": "object", "properties": {}, "required": []},
+                    "output": {"type": "object", "properties": {"result": {"type": "string"}}, "required": ["result"]},
+                    "prompts": {"system": "Analyse.", "user": "Go"},
+                }
+            }
+        )
+        coordinator_spec = _make_spec(
+            tasks={
+                "analyse": {
+                    "description": "Delegated — no 'task:' key",
+                    "spec": "shared.yaml",
+                    # no 'task:' — should default to "analyse"
+                }
+            }
+        )
+
+        _write_spec(tmp_path, "shared.yaml", shared_spec)
+        coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
+
+        def fake_invoke(system, user, config):
+            return json.dumps({"result": "done"})
+
+        with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
+            result = run_task_from_file(coordinator_path, task_name="analyse")
+
+        assert result["output"]["result"] == "done"
+        assert "shared.yaml#analyse" in result["delegated_to"]
+
+    def test_result_task_field_reflects_coordinator_name(self, tmp_path):
+        """Even when delegated task has a different internal name, envelope shows coordinator name."""
+        shared_spec = _make_spec(
+            tasks={
+                "internal_summarise": {
+                    "description": "Internal summariser",
+                    "input": {"type": "object", "properties": {}, "required": []},
+                    "output": {"type": "object", "properties": {"summary": {"type": "string"}}, "required": ["summary"]},
+                    "prompts": {"system": "Summarise.", "user": "Go"},
+                }
+            }
+        )
+        coordinator_spec = _make_spec(
+            tasks={
+                "summarise": {
+                    "description": "Public summarise task",
+                    "spec": "shared.yaml",
+                    "task": "internal_summarise",
+                }
+            }
+        )
+
+        _write_spec(tmp_path, "shared.yaml", shared_spec)
+        coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
+
+        with patch("oas_cli.runner.invoke_intelligence", lambda s, u, c: json.dumps({"summary": "brief"})):
+            result = run_task_from_file(coordinator_path, task_name="summarise")
+
+        assert result["task"] == "summarise"
+
+
+# ── Delegation + depends_on chain ─────────────────────────────────────────────
+
+
+class TestDelegationWithChain:
+    def test_delegated_task_feeds_downstream_via_depends_on(self, tmp_path):
+        """A delegated task's output merges into the next task's input."""
+        shared_spec = _make_spec(
+            tasks={
+                "extract": {
+                    "description": "Extract keywords",
+                    "input": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+                    "output": {"type": "object", "properties": {"keywords": {"type": "array", "items": {"type": "string"}}}, "required": ["keywords"]},
+                    "prompts": {"system": "Extract.", "user": "Extract from: {text}"},
+                }
+            }
+        )
+
+        coordinator_spec = _make_spec(
+            tasks={
+                "extract": {
+                    "description": "Delegated extractor",
+                    "spec": "shared.yaml",
+                    "task": "extract",
+                },
+                "report": {
+                    "description": "Build report from keywords",
+                    "depends_on": ["extract"],
+                    "input": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+                    "output": {"type": "object", "properties": {"report": {"type": "string"}}, "required": ["report"]},
+                    "prompts": {"system": "Report.", "user": "Report on keywords"},
+                },
+            }
+        )
+
+        _write_spec(tmp_path, "shared.yaml", shared_spec)
+        coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
+
+        call_count = {"n": 0}
+
+        def fake_invoke(system, user, config):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return json.dumps({"keywords": ["foo", "bar"]})
+            return json.dumps({"report": "Report about foo and bar"})
+
+        with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
+            result = run_task_from_file(
+                coordinator_path,
+                task_name="report",
+                input_data={"text": "Some text"},
+            )
+
+        assert result["output"]["report"] == "Report about foo and bar"
+        assert "extract" in result["chain"]
+        assert result["chain"]["extract"]["output"]["keywords"] == ["foo", "bar"]
+
+
+# ── Cycle detection ───────────────────────────────────────────────────────────
+
+
+class TestCycleDetection:
+    def test_self_delegation_raises(self, tmp_path):
+        """A spec that delegates a task to itself raises DELEGATION_CYCLE_ERROR."""
+        import yaml
+
+        spec_path = tmp_path / "self.yaml"
+        # Write a placeholder first so the path resolves
+        spec_path.write_text("")
+        spec = _make_spec(
+            tasks={
+                "do_thing": {
+                    "description": "Self-delegating",
+                    "spec": str(spec_path),   # absolute path to itself
+                    "task": "do_thing",
+                }
+            }
+        )
+        spec_path.write_text(yaml.dump(spec))
+
+        with pytest.raises(OARunError) as exc_info:
+            run_task_from_file(spec_path, task_name="do_thing")
+
+        assert exc_info.value.code == "DELEGATION_CYCLE_ERROR"
+
+    def test_mutual_delegation_raises(self, tmp_path):
+        """A → B → A cycle raises DELEGATION_CYCLE_ERROR."""
+        import yaml
+
+        path_a = tmp_path / "a.yaml"
+        path_b = tmp_path / "b.yaml"
+
+        # Write placeholders first
+        path_a.write_text("")
+        path_b.write_text("")
+
+        spec_a = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Delegates to B",
+                    "spec": str(path_b),
+                    "task": "run",
+                }
+            }
+        )
+        spec_b = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Delegates back to A",
+                    "spec": str(path_a),
+                    "task": "run",
+                }
+            }
+        )
+        path_a.write_text(yaml.dump(spec_a))
+        path_b.write_text(yaml.dump(spec_b))
+
+        with pytest.raises(OARunError) as exc_info:
+            run_task_from_file(path_a, task_name="run")
+
+        assert exc_info.value.code == "DELEGATION_CYCLE_ERROR"
+
+
+# ── Error cases ───────────────────────────────────────────────────────────────
+
+
+class TestDelegationErrors:
+    def test_missing_referenced_spec_raises(self, tmp_path):
+        """Referencing a spec file that doesn't exist raises SPEC_LOAD_ERROR."""
+        coordinator_spec = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Points at nothing",
+                    "spec": "./nonexistent/spec.yaml",
+                    "task": "run",
+                }
+            }
+        )
+        coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
+
+        with pytest.raises(OARunError) as exc_info:
+            run_task_from_file(coordinator_path, task_name="run")
+
+        assert exc_info.value.code == "SPEC_LOAD_ERROR"
+
+    def test_missing_task_in_referenced_spec_raises(self, tmp_path):
+        """Referencing a task that doesn't exist in the shared spec raises TASK_NOT_FOUND."""
+        shared_spec = _make_spec(
+            tasks={
+                "real_task": {
+                    "description": "exists",
+                    "input": {"type": "object", "properties": {}, "required": []},
+                    "output": {"type": "object", "properties": {"r": {"type": "string"}}, "required": ["r"]},
+                    "prompts": {"system": "s", "user": "u"},
+                }
+            }
+        )
+        coordinator_spec = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Wrong task name",
+                    "spec": "shared.yaml",
+                    "task": "ghost_task",
+                }
+            }
+        )
+
+        _write_spec(tmp_path, "shared.yaml", shared_spec)
+        coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
+
+        with pytest.raises(OARunError) as exc_info:
+            run_task_from_file(coordinator_path, task_name="run")
+
+        assert exc_info.value.code == "TASK_NOT_FOUND"
+
+    def test_relative_path_resolved_from_spec_directory(self, tmp_path):
+        """Relative spec: paths are resolved from the calling spec's directory, not cwd."""
+        sub = tmp_path / "agents"
+        sub.mkdir()
+
+        shared_spec = _make_spec(
+            tasks={
+                "ping": {
+                    "description": "ping",
+                    "input": {"type": "object", "properties": {}, "required": []},
+                    "output": {"type": "object", "properties": {"pong": {"type": "string"}}, "required": ["pong"]},
+                    "prompts": {"system": "s", "user": "u"},
+                }
+            }
+        )
+        coordinator_spec = _make_spec(
+            tasks={
+                "ping": {
+                    "description": "Delegated ping",
+                    "spec": "../shared/pinger.yaml",  # relative to agents/
+                    "task": "ping",
+                }
+            }
+        )
+
+        _write_spec(tmp_path / "shared", "pinger.yaml", shared_spec)
+        coordinator_path = _write_spec(sub, "coordinator.yaml", coordinator_spec)
+
+        with patch("oas_cli.runner.invoke_intelligence", lambda s, u, c: json.dumps({"pong": "ok"})):
+            result = run_task_from_file(coordinator_path, task_name="ping")
+
+        assert result["output"]["pong"] == "ok"
+
+
+# ── Validator ─────────────────────────────────────────────────────────────────
+
+
+class TestDelegationValidator:
+    def test_validator_accepts_delegated_task(self):
+        from oas_cli.validators import validate_spec
+
+        spec = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Delegated",
+                    "spec": "./shared/worker.yaml",
+                    "task": "work",
+                }
+            }
+        )
+        validate_spec(spec)  # must not raise
+
+    def test_validator_rejects_empty_spec_field(self):
+        from oas_cli.validators import validate_spec
+
+        spec = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Bad delegation",
+                    "spec": "",
+                }
+            }
+        )
+        with pytest.raises(ValueError, match="non-empty string"):
+            validate_spec(spec)
+
+    def test_validator_rejects_non_string_task_field(self):
+        from oas_cli.validators import validate_spec
+
+        spec = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Bad task field",
+                    "spec": "./shared.yaml",
+                    "task": 123,
+                }
+            }
+        )
+        with pytest.raises(ValueError, match=r"task.*string"):
+            validate_spec(spec)
+
+    def test_delegated_task_exempt_from_input_output_requirement(self):
+        """Delegated tasks don't need inline input/output schemas."""
+        from oas_cli.validators import validate_spec
+
+        spec = _make_spec(
+            tasks={
+                "run": {
+                    "description": "Delegated — no input/output",
+                    "spec": "./shared.yaml",
+                    # deliberately no input: or output:
+                }
+            }
+        )
+        validate_spec(spec)  # must not raise

--- a/tests/test_tool_providers.py
+++ b/tests/test_tool_providers.py
@@ -287,7 +287,7 @@ class TestRegistry:
         }
         pairs = resolve_task_tools(spec, "my_task")
         assert len(pairs) == 2
-        provider, defn = pairs[0]
+        _, defn = pairs[0]
         assert defn.name == "file_read"
 
     def test_resolve_task_tools_missing_top_level_raises(self):
@@ -421,7 +421,7 @@ class TestInvokeWithToolsLoop:
             from oas_cli.tool_providers.registry import resolve_task_tools
 
             tools = resolve_task_tools(spec, "ask")
-            result = _invoke_with_tools(
+            _invoke_with_tools(
                 "You are helpful.",
                 "user",
                 tools,


### PR DESCRIPTION
## Summary

- Tasks can now declare `spec: ./path/to/spec.yaml` + `task: name` to delegate their implementation to another spec — zero logic in the coordinator, full reuse from shared specialists
- `depends_on` is formally documented as a **data contract**, not execution control, with an explicit hard wall against branching, conditionals, loops, retries, and dynamic routing
- 13 new tests, 345 total passing, Ruff clean

## What's new

### Spec delegation

```yaml
tasks:
  summarise:
    description: Delegates to a shared summariser specialist
    spec: ./shared/summariser.yaml
    task: summarise

  sentiment_of_summary:
    description: Requires summarise output as input data, then delegates sentiment analysis
    depends_on: [summarise]
    spec: ./shared/sentiment.yaml
    task: analyse_sentiment
```

- Relative `spec:` paths resolve from the calling spec's directory
- `task:` is optional — defaults to the same name as the calling task
- Delegated tasks are exempt from inline `input`/`output` schema requirements
- Result envelope always surfaces the coordinator's task name + a `delegated_to` field for traceability
- `depends_on` chains work transparently across delegated tasks

### Cycle detection

A→B→A delegation loops raise `DELEGATION_CYCLE_ERROR` before any model call is made.

### depends_on design principle (codified)

> OAS describes what data a task needs and how it is implemented — never how execution should proceed.

The `REFERENCE.md` and JSON schema description for `depends_on` now explicitly state what OAS will not support: branching, conditionals, loops, retries, fallbacks, parallel execution, dynamic task selection. Those belong in the calling platform.

## Files changed

| File | Change |
|---|---|
| `oas_cli/runner.py` | Delegation logic in `_run_single_task`; `spec_path` threaded through chain |
| `oas_cli/schemas/oas-schema.json` | `spec` + `task` fields on task definitions; `output` moved out of JSON schema `required` |
| `oas_cli/validators.py` | Delegated tasks skip `input`/`output` requirement; validates `spec`/`task` field types |
| `docs/REFERENCE.md` | `depends_on` section rewritten with design principle + hard wall table |
| `tests/test_spec_composition.py` | 13 tests: basic delegation, chains, cycles, error cases, validator |
| `examples/spec-composition/` | Coordinator + two shared specialists (`summariser.yaml`, `sentiment.yaml`) + `run.sh` |

## Test plan

- [ ] `oa validate --spec examples/spec-composition/coordinator.yaml` passes
- [ ] `oa run --spec examples/spec-composition/coordinator.yaml --task summarise --input '{"text": "..."}'` returns delegated output
- [ ] `oa run --spec examples/spec-composition/coordinator.yaml --task sentiment_of_summary --input '{"text": "..."}'` runs chain + delegation
- [ ] Self-referencing spec raises `DELEGATION_CYCLE_ERROR`
- [ ] Referencing a non-existent spec raises `SPEC_LOAD_ERROR`
- [ ] `pytest tests/test_spec_composition.py` — 13 passed

Made with [Cursor](https://cursor.com)