### PR TITLE
chore: bump version to 1.4.0 across all files

### DIFF
--- a/.agents/ci-failure-repair.yaml
+++ b/.agents/ci-failure-repair.yaml
@@ -11,7 +11,7 @@
 #   oa run --spec .agents/ci-failure-repair.yaml --task diagnose_and_remediate \
 #     --input "$(jq -n --rawfile log log.txt '{workflow_name:"CI",branch:"main",job_log:$log}')" --quiet
 #
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: ci-failure-repair-agent

--- a/.agents/codex-runner.yaml
+++ b/.agents/codex-runner.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: codex-runner-agent

--- a/.agents/hello-world-agent.yaml
+++ b/.agents/hello-world-agent.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/.agents/review.yaml
+++ b/.agents/review.yaml
@@ -3,7 +3,7 @@
 #   git diff > change.diff
 #   oa run --spec .agents/review.yaml --task review --input change.diff --quiet
 #
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: code-reviewer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to **open-agent-spec** (Open Agent CLI) will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-03-19
+
+### Added
+- **Spec composition via task delegation** — a task can now declare `spec: ./path/to/spec.yaml` + `task: name` to delegate its implementation to another spec. The runner loads the referenced spec and executes that task transparently, returning the result under the coordinator's task name. Relative `spec:` paths resolve from the calling spec's directory.
+- Cycle detection for spec delegation: A→B→A loops raise a new `DELEGATION_CYCLE_ERROR` before any model call is made.
+- `delegated_to` field in the result envelope for traceability (`"spec_path#task_name"`).
+- New `spec` and `task` fields in the task JSON schema definition.
+- `examples/spec-composition/` — coordinator spec + two shared specialist specs (`summariser.yaml`, `sentiment.yaml`) and a demo `run.sh`.
+- `tests/test_spec_composition.py` — 13 tests covering basic delegation, `depends_on` chains across delegated tasks, cycle detection, error cases, relative path resolution, and validator.
+- **Tool use / MCP integration** — declarative tool definitions in the spec with three backends: `native` (built-in zero-dependency tools: `file.read`, `file.write`, `http.get`, `http.post`, `env.read`), `mcp` (JSON-RPC 2.0 over raw HTTP to any MCP server), and `custom` (dynamic Python class loading).
+- `ToolProvider` abstract base class and full provider registry (`oas_cli/tool_providers/`).
+- Multi-turn `_invoke_with_tools` loop in the runner for model-driven tool calling.
+- Native tool support in `OpenAIProvider` and `AnthropicProvider` via their function-calling APIs.
+- `examples/file-reader/`, `examples/mcp-local/`, `examples/mcp-search/` — self-contained tool demos.
+- **Provider interface** — all LLM calls now go through a minimal `IntelligenceProvider.invoke()` abstraction using raw HTTP (no OpenAI/Anthropic SDK required). Engine support extended to `grok`, `xai`, `local`, and `custom`.
+- **Test harness** (`oa test`) — run eval cases against a spec with assertions on task output.
+- **Spec reuse / composition** — `depends_on` formally documented as a data contract (not execution control), with an explicit hard wall against branching, conditionals, loops, retries, and dynamic routing.
+
+### Changed
+- `output` removed from the task JSON schema `required` array; enforced by the Python validator for non-delegated, non-multi-step tasks (enables delegated tasks to omit inline schema).
+- `depends_on` description in schema and `REFERENCE.md` updated with the design principle and a hard-wall table of features OAS intentionally does not support.
+- Spec version aligned to **1.4.0** across all examples, templates, `.agents/`, Website content, REFERENCE.md, CONTRIBUTING.md, and README.
+
+---
+
 ## [Unreleased]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The Open Agent Spec (OA) uses YAML files to define agent configurations. Use the
 
 #### Basic Structure
 ```yaml
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: my-agent
@@ -52,7 +52,7 @@ intelligence:
 
 1. Trading Agent:
 ```yaml
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: market-analyzer
@@ -71,7 +71,7 @@ intelligence:
 
 2. Content Generator:
 ```yaml
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: content-creator

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ oa run --spec .agents/review.yaml --task review --input change.diff --quiet
 Start from this shape:
 
 ```yaml
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/Website/content/codexSpec.ts
+++ b/Website/content/codexSpec.ts
@@ -1,5 +1,5 @@
 // Codex engine example spec. Keep in sync with codexSpec.yaml.
-export const CODEX_SPEC_YAML = `open_agent_spec: "1.3.0"
+export const CODEX_SPEC_YAML = `open_agent_spec: "1.4.0"
 
 agent:
   name: repo-refactor-agent

--- a/Website/content/codexSpec.yaml
+++ b/Website/content/codexSpec.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: repo-refactor-agent

--- a/Website/content/defaultSpec.ts
+++ b/Website/content/defaultSpec.ts
@@ -1,5 +1,5 @@
 // Default YAML shown in the playground editor. Keep in sync with defaultSpec.yaml.
-export const DEFAULT_SPEC_YAML = `open_agent_spec: "1.3.0"
+export const DEFAULT_SPEC_YAML = `open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/Website/content/defaultSpec.yaml
+++ b/Website/content/defaultSpec.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/Website/content/researchAssistantSpec.ts
+++ b/Website/content/researchAssistantSpec.ts
@@ -1,5 +1,5 @@
 // Research assistant example. Keep in sync with researchAssistantSpec.yaml.
-export const RESEARCH_ASSISTANT_SPEC_YAML = `open_agent_spec: "1.3.0"
+export const RESEARCH_ASSISTANT_SPEC_YAML = `open_agent_spec: "1.4.0"
 
 agent:
   name: research-assistant

--- a/Website/content/researchAssistantSpec.yaml
+++ b/Website/content/researchAssistantSpec.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: research-assistant

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -5,7 +5,7 @@ For a short intro, see the [README](../README.md). This page is the longer refer
 ## Spec file structure
 
 ```yaml
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: "hello-world-agent"

--- a/examples/file-reader/file-reader.yaml
+++ b/examples/file-reader/file-reader.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: file-reader

--- a/examples/mcp-local/agent.yaml
+++ b/examples/mcp-local/agent.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: text-analyser

--- a/examples/mcp-search/mcp-search.yaml
+++ b/examples/mcp-search/mcp-search.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: mcp-researcher

--- a/examples/spec-composition/coordinator.yaml
+++ b/examples/spec-composition/coordinator.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Spec Composition demo — coordinator.yaml

--- a/examples/spec-composition/shared/sentiment.yaml
+++ b/examples/spec-composition/shared/sentiment.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: shared-sentiment

--- a/examples/spec-composition/shared/summariser.yaml
+++ b/examples/spec-composition/shared/summariser.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: shared-summariser

--- a/oas_cli/templates/aac-example.yaml
+++ b/oas_cli/templates/aac-example.yaml
@@ -2,7 +2,7 @@
 #   oa run --spec .agents/example.yaml --task greet --input '{"name": "World"}' --quiet
 # Or generate code into a folder with:
 #   oa init --spec .agents/example.yaml --output ./my-agent
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/oas_cli/templates/aac-review.yaml
+++ b/oas_cli/templates/aac-review.yaml
@@ -3,7 +3,7 @@
 #   git diff > change.diff
 #   oa run --spec .agents/review.yaml --task review --input change.diff --quiet
 #
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: code-reviewer

--- a/oas_cli/templates/minimal-agent-tool-usage.yaml
+++ b/oas_cli/templates/minimal-agent-tool-usage.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/oas_cli/templates/minimal-agent.yaml
+++ b/oas_cli/templates/minimal-agent.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/oas_cli/templates/minimal-multi-task-agent.yaml
+++ b/oas_cli/templates/minimal-multi-task-agent.yaml
@@ -1,4 +1,4 @@
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: hello-world-agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-agent-spec"
-version = "1.3.0"
+version = "1.4.0"
 description = "YAML-first agent specs: run with `oa run` or generate a full Python project with `oa init`."
 authors = [{ name = "Andrew Whitehouse", email = "andrewswhitehouse@gmail.com" }]
 license = { text = "MIT" }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,7 +79,7 @@ def test_init_with_directory_spec_returns_clean_error(tmp_path):
 # ---------------------------------------------------------------------------
 
 _MINIMAL_SPEC = """\
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: test-agent

--- a/tests/test_multi_task_workflows.py
+++ b/tests/test_multi_task_workflows.py
@@ -98,7 +98,7 @@ def _spec(
         prompts.update(style_b)
 
     s: dict = {
-        "open_agent_spec": "1.3.0",
+        "open_agent_spec": "1.4.0",
         "agent": {"name": "test-agent", "description": "test agent"},
         "intelligence": intelligence or _base_intelligence(),
         "tasks": tasks,
@@ -168,7 +168,7 @@ class TestPromptResolutionLayers:
     def test_no_prompts_section_at_all(self):
         """Spec without any prompts key (per-task or global) runs without error."""
         spec = {
-            "open_agent_spec": "1.3.0",
+            "open_agent_spec": "1.4.0",
             "agent": {"name": "a", "description": "b"},
             "intelligence": _base_intelligence(),
             "tasks": {"t": _task(system="task-sys", user="{{ q }}")},
@@ -658,7 +658,7 @@ class TestSpecShapePermutations:
     def test_per_task_only_no_global_prompts(self):
         """Spec with no top-level prompts section; each task has its own."""
         spec = {
-            "open_agent_spec": "1.3.0",
+            "open_agent_spec": "1.4.0",
             "agent": {"name": "a", "description": "b"},
             "intelligence": _base_intelligence(),
             "tasks": {
@@ -861,7 +861,7 @@ class TestCodeAssistantScenario:
 # ===========================================================================
 
 _CLI_SPEC_YAML = """\
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: cli-test-agent

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -53,7 +53,7 @@ def _spec(
         prompts["mytask"] = b
 
     return {
-        "open_agent_spec": "1.3.0",
+        "open_agent_spec": "1.4.0",
         "agent": {"name": "test-agent", "description": "test"},
         "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o"},
         "tasks": {"mytask": task_def},
@@ -271,7 +271,7 @@ class TestRunTaskFromSpecOverrides:
 def _text_spec(response_format: str = "text") -> dict:
     """Minimal spec with response_format on the task."""
     return {
-        "open_agent_spec": "1.3.0",
+        "open_agent_spec": "1.4.0",
         "agent": {"name": "ta", "description": "ta"},
         "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o"},
         "tasks": {
@@ -411,7 +411,7 @@ def _chain_spec(*, add_text_format: bool = False) -> dict:
     if add_text_format:
         summarize_task["response_format"] = "text"
     return {
-        "open_agent_spec": "1.3.0",
+        "open_agent_spec": "1.4.0",
         "agent": {"name": "chain-agent", "description": "test"},
         "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o"},
         "tasks": {"extract": extract_task, "summarize": summarize_task},
@@ -597,7 +597,7 @@ class TestResolveContract:
         task_fields: list[str] | None = None,
     ) -> dict:
         spec: dict = {
-            "open_agent_spec": "1.3.0",
+            "open_agent_spec": "1.4.0",
             "agent": {"name": "ta", "description": "ta"},
             "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o"},
             "tasks": {
@@ -681,7 +681,7 @@ class TestContractEnforcementLive:
             },
         }
         return {
-            "open_agent_spec": "1.3.0",
+            "open_agent_spec": "1.4.0",
             "agent": {"name": "ta", "description": "ta"},
             "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o"},
             "tasks": {"mytask": task},
@@ -728,7 +728,7 @@ class TestContractEnforcementLive:
             lambda s, u, c: '{"summary": "ok"}',  # missing global 'confidence'
         )
         spec = {
-            "open_agent_spec": "1.3.0",
+            "open_agent_spec": "1.4.0",
             "agent": {"name": "ta", "description": "ta"},
             "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o"},
             "tasks": {
@@ -763,7 +763,7 @@ class TestContractEnforcementLive:
 
         monkeypatch.setattr("oas_cli.runner.invoke_intelligence", fake_invoke)
         spec = {
-            "open_agent_spec": "1.3.0",
+            "open_agent_spec": "1.4.0",
             "agent": {"name": "ta", "description": "ta"},
             "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o"},
             "tasks": {

--- a/tests/test_spec_composition.py
+++ b/tests/test_spec_composition.py
@@ -26,7 +26,7 @@ _INTELLIGENCE = {
 
 def _make_spec(tasks: dict, prompts: dict | None = None) -> dict:
     return {
-        "open_agent_spec": "1.3.0",
+        "open_agent_spec": "1.4.0",
         "agent": {"name": "test", "description": "test", "role": "analyst"},
         "intelligence": _INTELLIGENCE,
         "tasks": tasks,

--- a/tests/test_spec_test.py
+++ b/tests/test_spec_test.py
@@ -73,7 +73,7 @@ def test_load_test_definition_roundtrip(tmp_path: Path):
 
 
 _MINIMAL_RUNNABLE_SPEC = """\
-open_agent_spec: "1.3.0"
+open_agent_spec: "1.4.0"
 
 agent:
   name: test-agent

--- a/tests/test_tool_providers.py
+++ b/tests/test_tool_providers.py
@@ -323,7 +323,7 @@ class TestInvokeWithToolsLoop:
 
     def _make_spec(self) -> dict:
         return {
-            "open_agent_spec": "1.3.0",
+            "open_agent_spec": "1.4.0",
             "agent": {"name": "test", "description": "test"},
             "intelligence": {
                 "type": "llm",


### PR DESCRIPTION
## Summary

The version bump commit was pushed to `feat/spec-composition` after PR #68 was already merged, so it never landed on `main`. This cherry-picks that commit.

- `pyproject.toml` → `1.4.0`
- All spec files (`open_agent_spec:`) in examples, templates, `.agents/`, Website content → `1.4.0`
- All test fixtures → `1.4.0`
- `CHANGELOG.md` — new `1.4.0` entry added
- `docs/REFERENCE.md` example spec → `1.4.0`
- `README.md`, `CONTRIBUTING.md` example specs → `1.4.0`

This is what's causing the Website to still show `1.3.0` on Vercel.

Made with [Cursor](https://cursor.com)