### PR TITLE
feat: spec registry at openagentspec.dev/registry with oa:// URL scheme

### DIFF
--- a/Website/public/registry/index.json
+++ b/Website/public/registry/index.json
@@ -1,0 +1,72 @@
+{
+  "registry": "openagentspec.dev",
+  "version": "1.0",
+  "updated": "2026-03-19",
+  "specs": [
+    {
+      "id": "prime-vector/summariser",
+      "name": "Summariser",
+      "description": "Summarise a body of text and extract the most important key points.",
+      "namespace": "prime-vector",
+      "slug": "summariser",
+      "latest": "1.0.0",
+      "versions": ["1.0.0"],
+      "tags": ["text", "nlp", "summarisation"],
+      "usage": "spec: oa://prime-vector/summariser",
+      "task": "summarise",
+      "url": "https://openagentspec.dev/registry/prime-vector/summariser/latest/spec.yaml"
+    },
+    {
+      "id": "prime-vector/sentiment",
+      "name": "Sentiment Analyser",
+      "description": "Analyse the sentiment of text — positive, negative, neutral, or mixed — with a confidence score.",
+      "namespace": "prime-vector",
+      "slug": "sentiment",
+      "latest": "1.0.0",
+      "versions": ["1.0.0"],
+      "tags": ["text", "nlp", "sentiment", "classification"],
+      "usage": "spec: oa://prime-vector/sentiment",
+      "task": "analyse_sentiment",
+      "url": "https://openagentspec.dev/registry/prime-vector/sentiment/latest/spec.yaml"
+    },
+    {
+      "id": "prime-vector/classifier",
+      "name": "Text Classifier",
+      "description": "Classify text into one of a set of categories provided at runtime. Works for any classification problem.",
+      "namespace": "prime-vector",
+      "slug": "classifier",
+      "latest": "1.0.0",
+      "versions": ["1.0.0"],
+      "tags": ["text", "nlp", "classification"],
+      "usage": "spec: oa://prime-vector/classifier",
+      "task": "classify",
+      "url": "https://openagentspec.dev/registry/prime-vector/classifier/latest/spec.yaml"
+    },
+    {
+      "id": "prime-vector/keyword-extractor",
+      "name": "Keyword Extractor",
+      "description": "Extract the most relevant keywords and key phrases from a body of text, ordered by relevance.",
+      "namespace": "prime-vector",
+      "slug": "keyword-extractor",
+      "latest": "1.0.0",
+      "versions": ["1.0.0"],
+      "tags": ["text", "nlp", "keywords", "extraction"],
+      "usage": "spec: oa://prime-vector/keyword-extractor",
+      "task": "extract_keywords",
+      "url": "https://openagentspec.dev/registry/prime-vector/keyword-extractor/latest/spec.yaml"
+    },
+    {
+      "id": "prime-vector/code-reviewer",
+      "name": "Code Reviewer",
+      "description": "Review a code snippet for bugs, security issues, and improvement opportunities. Returns structured feedback with severity ratings.",
+      "namespace": "prime-vector",
+      "slug": "code-reviewer",
+      "latest": "1.0.0",
+      "versions": ["1.0.0"],
+      "tags": ["code", "review", "security", "quality"],
+      "usage": "spec: oa://prime-vector/code-reviewer",
+      "task": "review_code",
+      "url": "https://openagentspec.dev/registry/prime-vector/code-reviewer/latest/spec.yaml"
+    }
+  ]
+}

--- a/Website/public/registry/prime-vector/classifier/1.0.0/spec.yaml
+++ b/Website/public/registry/prime-vector/classifier/1.0.0/spec.yaml
@@ -1,0 +1,69 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: classifier
+  description: >
+    Classify a piece of text into one of a set of provided categories.
+    Categories are passed at runtime so the same spec works for any
+    classification problem. Designed to be reused via spec delegation
+    (spec: oa://prime-vector/classifier).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.1
+
+tasks:
+  classify:
+    description: >
+      Classify text into one of the provided categories. Pass the
+      available categories as a comma-separated string in the input.
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to classify
+        categories:
+          type: string
+          description: >
+            Comma-separated list of valid categories,
+            e.g. "bug, feature, question, documentation"
+      required:
+        - text
+        - categories
+    output:
+      type: object
+      properties:
+        category:
+          type: string
+          description: The assigned category (must be one of the provided categories)
+        confidence:
+          type: number
+          description: Confidence score between 0.0 and 1.0
+        reasoning:
+          type: string
+          description: Brief explanation of the classification
+      required:
+        - category
+        - confidence
+        - reasoning
+    prompts:
+      system: >
+        You are a precise classification engine. Classify the input text into
+        exactly one of the provided categories. Always respond with valid JSON.
+      user: |
+        Classify the following text into one of these categories: {categories}
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "category": "<one of the provided categories>",
+          "confidence": 0.0-1.0,
+          "reasoning": "<brief explanation>"
+        }

--- a/Website/public/registry/prime-vector/classifier/latest/spec.yaml
+++ b/Website/public/registry/prime-vector/classifier/latest/spec.yaml
@@ -1,0 +1,69 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: classifier
+  description: >
+    Classify a piece of text into one of a set of provided categories.
+    Categories are passed at runtime so the same spec works for any
+    classification problem. Designed to be reused via spec delegation
+    (spec: oa://prime-vector/classifier).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.1
+
+tasks:
+  classify:
+    description: >
+      Classify text into one of the provided categories. Pass the
+      available categories as a comma-separated string in the input.
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to classify
+        categories:
+          type: string
+          description: >
+            Comma-separated list of valid categories,
+            e.g. "bug, feature, question, documentation"
+      required:
+        - text
+        - categories
+    output:
+      type: object
+      properties:
+        category:
+          type: string
+          description: The assigned category (must be one of the provided categories)
+        confidence:
+          type: number
+          description: Confidence score between 0.0 and 1.0
+        reasoning:
+          type: string
+          description: Brief explanation of the classification
+      required:
+        - category
+        - confidence
+        - reasoning
+    prompts:
+      system: >
+        You are a precise classification engine. Classify the input text into
+        exactly one of the provided categories. Always respond with valid JSON.
+      user: |
+        Classify the following text into one of these categories: {categories}
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "category": "<one of the provided categories>",
+          "confidence": 0.0-1.0,
+          "reasoning": "<brief explanation>"
+        }

--- a/Website/public/registry/prime-vector/code-reviewer/1.0.0/spec.yaml
+++ b/Website/public/registry/prime-vector/code-reviewer/1.0.0/spec.yaml
@@ -1,0 +1,84 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: code-reviewer
+  description: >
+    Review a code snippet for bugs, security issues, and improvement
+    opportunities. Returns structured feedback with severity ratings.
+    Designed to be reused via spec delegation
+    (spec: oa://prime-vector/code-reviewer).
+  role: reviewer
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.2
+
+tasks:
+  review_code:
+    description: Review code for bugs, security issues, and improvements
+    input:
+      type: object
+      properties:
+        code:
+          type: string
+          description: The code snippet to review
+        language:
+          type: string
+          description: Programming language (e.g. python, typescript, go)
+        context:
+          type: string
+          description: Optional context about what the code is supposed to do
+      required:
+        - code
+        - language
+    output:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: "Overall verdict: approved, approved_with_suggestions, needs_changes"
+        issues:
+          type: array
+          items:
+            type: object
+          description: List of issues found, each with severity, line, and description
+        suggestions:
+          type: array
+          items:
+            type: string
+          description: General improvement suggestions not tied to a specific line
+        summary:
+          type: string
+          description: A brief overall summary of the review
+      required:
+        - verdict
+        - issues
+        - suggestions
+        - summary
+    prompts:
+      system: >
+        You are an experienced software engineer conducting a thorough code review.
+        Identify bugs, security vulnerabilities, and improvement opportunities.
+        Be specific, constructive, and concise. Always respond with valid JSON.
+      user: |
+        Review the following {language} code.
+
+        {context}
+
+        Code:
+        ```{language}
+        {code}
+        ```
+
+        Respond with JSON:
+        {
+          "verdict": "approved|approved_with_suggestions|needs_changes",
+          "issues": [
+            {"severity": "critical|high|medium|low", "description": "...", "line": null}
+          ],
+          "suggestions": ["suggestion 1", "suggestion 2"],
+          "summary": "<brief overall summary>"
+        }

--- a/Website/public/registry/prime-vector/code-reviewer/latest/spec.yaml
+++ b/Website/public/registry/prime-vector/code-reviewer/latest/spec.yaml
@@ -1,0 +1,84 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: code-reviewer
+  description: >
+    Review a code snippet for bugs, security issues, and improvement
+    opportunities. Returns structured feedback with severity ratings.
+    Designed to be reused via spec delegation
+    (spec: oa://prime-vector/code-reviewer).
+  role: reviewer
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.2
+
+tasks:
+  review_code:
+    description: Review code for bugs, security issues, and improvements
+    input:
+      type: object
+      properties:
+        code:
+          type: string
+          description: The code snippet to review
+        language:
+          type: string
+          description: Programming language (e.g. python, typescript, go)
+        context:
+          type: string
+          description: Optional context about what the code is supposed to do
+      required:
+        - code
+        - language
+    output:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: "Overall verdict: approved, approved_with_suggestions, needs_changes"
+        issues:
+          type: array
+          items:
+            type: object
+          description: List of issues found, each with severity, line, and description
+        suggestions:
+          type: array
+          items:
+            type: string
+          description: General improvement suggestions not tied to a specific line
+        summary:
+          type: string
+          description: A brief overall summary of the review
+      required:
+        - verdict
+        - issues
+        - suggestions
+        - summary
+    prompts:
+      system: >
+        You are an experienced software engineer conducting a thorough code review.
+        Identify bugs, security vulnerabilities, and improvement opportunities.
+        Be specific, constructive, and concise. Always respond with valid JSON.
+      user: |
+        Review the following {language} code.
+
+        {context}
+
+        Code:
+        ```{language}
+        {code}
+        ```
+
+        Respond with JSON:
+        {
+          "verdict": "approved|approved_with_suggestions|needs_changes",
+          "issues": [
+            {"severity": "critical|high|medium|low", "description": "...", "line": null}
+          ],
+          "suggestions": ["suggestion 1", "suggestion 2"],
+          "summary": "<brief overall summary>"
+        }

--- a/Website/public/registry/prime-vector/keyword-extractor/1.0.0/spec.yaml
+++ b/Website/public/registry/prime-vector/keyword-extractor/1.0.0/spec.yaml
@@ -1,0 +1,64 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: keyword-extractor
+  description: >
+    Extract the most relevant keywords and key phrases from a body of text.
+    Designed to be reused via spec delegation
+    (spec: oa://prime-vector/keyword-extractor).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.1
+
+tasks:
+  extract_keywords:
+    description: Extract keywords and key phrases from text
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to extract keywords from
+        max_keywords:
+          type: string
+          description: Maximum number of keywords to return (default 10)
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Extracted keywords ordered by relevance
+        phrases:
+          type: array
+          items:
+            type: string
+          description: Key multi-word phrases extracted from the text
+      required:
+        - keywords
+        - phrases
+    prompts:
+      system: >
+        You are a precise keyword extraction engine. Extract the most
+        relevant individual keywords and key phrases from the provided text.
+        Order by relevance. Always respond with valid JSON.
+      user: |
+        Extract keywords and key phrases from the following text.
+        Return at most {max_keywords} keywords (default 10 if not specified).
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "keywords": ["keyword1", "keyword2", ...],
+          "phrases": ["key phrase 1", "key phrase 2", ...]
+        }

--- a/Website/public/registry/prime-vector/keyword-extractor/latest/spec.yaml
+++ b/Website/public/registry/prime-vector/keyword-extractor/latest/spec.yaml
@@ -1,0 +1,64 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: keyword-extractor
+  description: >
+    Extract the most relevant keywords and key phrases from a body of text.
+    Designed to be reused via spec delegation
+    (spec: oa://prime-vector/keyword-extractor).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.1
+
+tasks:
+  extract_keywords:
+    description: Extract keywords and key phrases from text
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to extract keywords from
+        max_keywords:
+          type: string
+          description: Maximum number of keywords to return (default 10)
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Extracted keywords ordered by relevance
+        phrases:
+          type: array
+          items:
+            type: string
+          description: Key multi-word phrases extracted from the text
+      required:
+        - keywords
+        - phrases
+    prompts:
+      system: >
+        You are a precise keyword extraction engine. Extract the most
+        relevant individual keywords and key phrases from the provided text.
+        Order by relevance. Always respond with valid JSON.
+      user: |
+        Extract keywords and key phrases from the following text.
+        Return at most {max_keywords} keywords (default 10 if not specified).
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "keywords": ["keyword1", "keyword2", ...],
+          "phrases": ["key phrase 1", "key phrase 2", ...]
+        }

--- a/Website/public/registry/prime-vector/sentiment/1.0.0/spec.yaml
+++ b/Website/public/registry/prime-vector/sentiment/1.0.0/spec.yaml
@@ -1,0 +1,61 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: sentiment
+  description: >
+    Analyse the sentiment of a piece of text. Returns a sentiment label,
+    confidence score, and brief reasoning. Designed to be reused via
+    spec delegation (spec: oa://prime-vector/sentiment).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.1
+
+tasks:
+  analyse_sentiment:
+    description: Determine the overall sentiment of a piece of text
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to analyse
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        sentiment:
+          type: string
+          description: "One of: positive, negative, neutral, mixed"
+        confidence:
+          type: number
+          description: Confidence score between 0.0 and 1.0
+        reasoning:
+          type: string
+          description: Brief explanation of the sentiment verdict
+      required:
+        - sentiment
+        - confidence
+        - reasoning
+    prompts:
+      system: >
+        You are a precise sentiment analysis engine. Classify the sentiment of
+        the provided text as positive, negative, neutral, or mixed.
+        Always respond with valid JSON.
+      user: |
+        Analyse the sentiment of the following text.
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "sentiment": "positive|negative|neutral|mixed",
+          "confidence": 0.0-1.0,
+          "reasoning": "<brief explanation>"
+        }

--- a/Website/public/registry/prime-vector/sentiment/latest/spec.yaml
+++ b/Website/public/registry/prime-vector/sentiment/latest/spec.yaml
@@ -1,0 +1,61 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: sentiment
+  description: >
+    Analyse the sentiment of a piece of text. Returns a sentiment label,
+    confidence score, and brief reasoning. Designed to be reused via
+    spec delegation (spec: oa://prime-vector/sentiment).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.1
+
+tasks:
+  analyse_sentiment:
+    description: Determine the overall sentiment of a piece of text
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to analyse
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        sentiment:
+          type: string
+          description: "One of: positive, negative, neutral, mixed"
+        confidence:
+          type: number
+          description: Confidence score between 0.0 and 1.0
+        reasoning:
+          type: string
+          description: Brief explanation of the sentiment verdict
+      required:
+        - sentiment
+        - confidence
+        - reasoning
+    prompts:
+      system: >
+        You are a precise sentiment analysis engine. Classify the sentiment of
+        the provided text as positive, negative, neutral, or mixed.
+        Always respond with valid JSON.
+      user: |
+        Analyse the sentiment of the following text.
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "sentiment": "positive|negative|neutral|mixed",
+          "confidence": 0.0-1.0,
+          "reasoning": "<brief explanation>"
+        }

--- a/Website/public/registry/prime-vector/summariser/1.0.0/spec.yaml
+++ b/Website/public/registry/prime-vector/summariser/1.0.0/spec.yaml
@@ -1,0 +1,57 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: summariser
+  description: >
+    Summarise a body of text and extract the most important points.
+    A general-purpose summarisation specialist designed to be reused
+    via spec delegation (spec: oa://prime-vector/summariser).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.2
+
+tasks:
+  summarise:
+    description: Summarise text and extract key points
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to summarise
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        summary:
+          type: string
+          description: A concise summary of the text (one to three sentences)
+        key_points:
+          type: array
+          items:
+            type: string
+          description: Up to five key points extracted from the text
+      required:
+        - summary
+        - key_points
+    prompts:
+      system: >
+        You are a concise technical writer. Summarise clearly and extract the
+        most important points. Always respond with valid JSON.
+      user: |
+        Summarise the following text and extract the key points.
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "summary": "<one to three sentences>",
+          "key_points": ["point 1", "point 2", ...]
+        }

--- a/Website/public/registry/prime-vector/summariser/latest/spec.yaml
+++ b/Website/public/registry/prime-vector/summariser/latest/spec.yaml
@@ -1,0 +1,57 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: summariser
+  description: >
+    Summarise a body of text and extract the most important points.
+    A general-purpose summarisation specialist designed to be reused
+    via spec delegation (spec: oa://prime-vector/summariser).
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.2
+
+tasks:
+  summarise:
+    description: Summarise text and extract key points
+    input:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The text to summarise
+      required:
+        - text
+    output:
+      type: object
+      properties:
+        summary:
+          type: string
+          description: A concise summary of the text (one to three sentences)
+        key_points:
+          type: array
+          items:
+            type: string
+          description: Up to five key points extracted from the text
+      required:
+        - summary
+        - key_points
+    prompts:
+      system: >
+        You are a concise technical writer. Summarise clearly and extract the
+        most important points. Always respond with valid JSON.
+      user: |
+        Summarise the following text and extract the key points.
+
+        Text:
+        {text}
+
+        Respond with JSON:
+        {
+          "summary": "<one to three sentences>",
+          "key_points": ["point 1", "point 2", ...]
+        }

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -113,7 +113,7 @@ def _resolve_spec_url(ref: str) -> str:
     if not ref.startswith(_OA_SCHEME):
         return ref  # already a plain HTTP(S) URL
 
-    rest = ref[len(_OA_SCHEME):]
+    rest = ref[len(_OA_SCHEME) :]
     version = "latest"
     if "@" in rest:
         rest, version = rest.rsplit("@", 1)
@@ -135,7 +135,11 @@ def _resolve_spec_url(ref: str) -> str:
 
 def _is_remote_ref(ref: str) -> bool:
     """Return True when *ref* should be fetched over HTTP rather than disk."""
-    return ref.startswith(_OA_SCHEME) or ref.startswith("http://") or ref.startswith("https://")
+    return (
+        ref.startswith(_OA_SCHEME)
+        or ref.startswith("http://")
+        or ref.startswith("https://")
+    )
 
 
 def _fetch_remote_spec(url: str) -> dict[str, Any]:

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import re
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +25,10 @@ from .tool_providers import (
     resolve_task_tools,
 )
 from .tool_providers.base import InvokeResult
+
+# ── Registry constants ────────────────────────────────────────────────────────
+_REGISTRY_BASE = "https://openagentspec.dev/registry"
+_OA_SCHEME = "oa://"
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +95,86 @@ def _load_spec(path: Path) -> dict[str, Any]:
             "Spec YAML must decode to a mapping/object",
             code="SPEC_LOAD_ERROR",
             stage="load",
+        )
+    return data
+
+
+def _resolve_spec_url(ref: str) -> str:
+    """Expand an ``oa://`` shorthand into a full HTTPS registry URL.
+
+    Supported formats:
+        oa://namespace/name            → registry/.../latest/spec.yaml
+        oa://namespace/name@1.0.0      → registry/.../1.0.0/spec.yaml
+        https://...                    → returned as-is
+        http://...                     → returned as-is
+
+    Local paths are not handled here — caller checks ``_is_remote_ref`` first.
+    """
+    if not ref.startswith(_OA_SCHEME):
+        return ref  # already a plain HTTP(S) URL
+
+    rest = ref[len(_OA_SCHEME):]
+    version = "latest"
+    if "@" in rest:
+        rest, version = rest.rsplit("@", 1)
+
+    parts = rest.strip("/").split("/")
+    if len(parts) != 2:
+        raise OARunError(
+            f"Invalid oa:// reference '{ref}'. "
+            "Expected format: oa://namespace/name or oa://namespace/name@version",
+            code="SPEC_LOAD_ERROR",
+            stage="delegation",
+        )
+
+    namespace, name = parts
+    url = f"{_REGISTRY_BASE}/{namespace}/{name}/{version}/spec.yaml"
+    logger.debug("[registry] resolved %s → %s", ref, url)
+    return url
+
+
+def _is_remote_ref(ref: str) -> bool:
+    """Return True when *ref* should be fetched over HTTP rather than disk."""
+    return ref.startswith(_OA_SCHEME) or ref.startswith("http://") or ref.startswith("https://")
+
+
+def _fetch_remote_spec(url: str) -> dict[str, Any]:
+    """Download a spec YAML from a URL and return the parsed dict."""
+    logger.debug("[registry] fetching %s", url)
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={"Accept": "application/yaml, text/yaml, text/plain, */*"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise OARunError(
+            f"Registry fetch failed for '{url}': HTTP {exc.code} {exc.reason}",
+            code="SPEC_LOAD_ERROR",
+            stage="delegation",
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise OARunError(
+            f"Registry fetch failed for '{url}': {exc.reason}",
+            code="SPEC_LOAD_ERROR",
+            stage="delegation",
+        ) from exc
+
+    try:
+        data = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        raise OARunError(
+            f"Invalid YAML from registry '{url}': {exc}",
+            code="SPEC_LOAD_ERROR",
+            stage="delegation",
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise OARunError(
+            f"Registry spec at '{url}' must decode to a mapping/object",
+            code="SPEC_LOAD_ERROR",
+            stage="delegation",
         )
     return data
 
@@ -478,26 +564,44 @@ def _run_single_task(
                 task=task_name,
             )
 
-        # Resolve path relative to the calling spec's directory.
-        ref = Path(delegation_spec_ref.strip())
-        if not ref.is_absolute() and spec_path is not None:
-            ref = (spec_path.parent / ref).resolve()
+        raw_ref = delegation_spec_ref.strip()
+
+        # ── Remote spec (oa:// or https://) ──────────────────────────────
+        if _is_remote_ref(raw_ref):
+            url = _resolve_spec_url(raw_ref)
+            # Use URL string as the cycle-detection key.
+            canonical_key: Any = url
+            if canonical_key in _visited_specs:
+                raise OARunError(
+                    f"Circular spec delegation detected: '{url}' is already in "
+                    "the delegation stack",
+                    code="DELEGATION_CYCLE_ERROR",
+                    stage="delegation",
+                    task=task_name,
+                )
+            delegated_spec = _fetch_remote_spec(url)
+            new_visited = _visited_specs | {canonical_key}
+            canonical: Any = url  # used for logging + result envelope below
+
+        # ── Local path (relative or absolute) ────────────────────────────
         else:
-            ref = ref.resolve()
+            ref = Path(raw_ref)
+            if not ref.is_absolute() and spec_path is not None:
+                ref = (spec_path.parent / ref).resolve()
+            else:
+                ref = ref.resolve()
 
-        # Cycle guard — prevent A → B → A loops.
-        canonical = ref
-        if canonical in _visited_specs:
-            raise OARunError(
-                f"Circular spec delegation detected: '{canonical}' is already in "
-                "the delegation stack",
-                code="DELEGATION_CYCLE_ERROR",
-                stage="delegation",
-                task=task_name,
-            )
-
-        delegated_spec = _load_spec(canonical)
-        new_visited = _visited_specs | {canonical}
+            canonical = ref
+            if canonical in _visited_specs:
+                raise OARunError(
+                    f"Circular spec delegation detected: '{canonical}' is already in "
+                    "the delegation stack",
+                    code="DELEGATION_CYCLE_ERROR",
+                    stage="delegation",
+                    task=task_name,
+                )
+            delegated_spec = _load_spec(canonical)
+            new_visited = _visited_specs | {canonical}
 
         # Use the explicitly named task, or fall back to same name as the caller.
         delegated_task: str = task_def.get("task") or task_name
@@ -521,13 +625,17 @@ def _run_single_task(
             delegated_task,
         )
 
+        # For remote specs there is no local path, so pass None for spec_path.
+        # Relative references inside a remote spec will also resolve remotely.
+        next_spec_path = canonical if isinstance(canonical, Path) else None
+
         result = _run_single_task(
             delegated_spec,
             delegated_task,
             input_data,
             override_system,
             override_user,
-            spec_path=canonical,
+            spec_path=next_spec_path,
             _visited_specs=new_visited,
         )
         # Surface the coordinator's task name so the envelope is consistent

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -110,7 +110,10 @@ _MINIMAL_SPEC_YAML = yaml.dump(
 
 class TestFetchRemoteSpec:
     def test_successful_fetch(self):
-        with patch("urllib.request.urlopen", return_value=_make_mock_response(_MINIMAL_SPEC_YAML)):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_mock_response(_MINIMAL_SPEC_YAML),
+        ):
             spec = _fetch_remote_spec("https://example.com/spec.yaml")
         assert spec["open_agent_spec"] == "1.4.0"
         assert "tasks" in spec
@@ -118,13 +121,16 @@ class TestFetchRemoteSpec:
     def test_http_error_raises(self):
         import urllib.error
 
-        with patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError(
-            url="https://example.com/spec.yaml",
-            code=404,
-            msg="Not Found",
-            hdrs=None,  # type: ignore[arg-type]
-            fp=None,
-        )):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url="https://example.com/spec.yaml",
+                code=404,
+                msg="Not Found",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=None,
+            ),
+        ):
             with pytest.raises(OARunError) as exc_info:
                 _fetch_remote_spec("https://example.com/spec.yaml")
         assert exc_info.value.code == "SPEC_LOAD_ERROR"
@@ -133,19 +139,28 @@ class TestFetchRemoteSpec:
     def test_url_error_raises(self):
         import urllib.error
 
-        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("connection refused")):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
             with pytest.raises(OARunError) as exc_info:
                 _fetch_remote_spec("https://example.com/spec.yaml")
         assert exc_info.value.code == "SPEC_LOAD_ERROR"
 
     def test_invalid_yaml_raises(self):
-        with patch("urllib.request.urlopen", return_value=_make_mock_response(":: not valid yaml ::")):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_mock_response(":: not valid yaml ::"),
+        ):
             with pytest.raises(OARunError) as exc_info:
                 _fetch_remote_spec("https://example.com/spec.yaml")
         assert exc_info.value.code == "SPEC_LOAD_ERROR"
 
     def test_non_mapping_yaml_raises(self):
-        with patch("urllib.request.urlopen", return_value=_make_mock_response("- just\n- a\n- list\n")):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_mock_response("- just\n- a\n- list\n"),
+        ):
             with pytest.raises(OARunError) as exc_info:
                 _fetch_remote_spec("https://example.com/spec.yaml")
         assert exc_info.value.code == "SPEC_LOAD_ERROR"
@@ -179,8 +194,13 @@ class TestRemoteDelegation:
     def test_oa_url_delegation_executes_remote_spec(self, tmp_path):
         coordinator = self._write_coordinator(tmp_path, "oa://prime-vector/summariser")
 
-        with patch("oas_cli.runner._fetch_remote_spec", return_value=yaml.safe_load(_MINIMAL_SPEC_YAML)):
-            with patch("oas_cli.runner.invoke_intelligence", return_value='{"result": "ok"}'):
+        with patch(
+            "oas_cli.runner._fetch_remote_spec",
+            return_value=yaml.safe_load(_MINIMAL_SPEC_YAML),
+        ):
+            with patch(
+                "oas_cli.runner.invoke_intelligence", return_value='{"result": "ok"}'
+            ):
                 result = run_task_from_file(coordinator, task_name="delegate")
 
         assert result["task"] == "delegate"
@@ -192,8 +212,13 @@ class TestRemoteDelegation:
             tmp_path, "https://example.com/specs/myspec.yaml"
         )
 
-        with patch("oas_cli.runner._fetch_remote_spec", return_value=yaml.safe_load(_MINIMAL_SPEC_YAML)):
-            with patch("oas_cli.runner.invoke_intelligence", return_value='{"result": "ok"}'):
+        with patch(
+            "oas_cli.runner._fetch_remote_spec",
+            return_value=yaml.safe_load(_MINIMAL_SPEC_YAML),
+        ):
+            with patch(
+                "oas_cli.runner.invoke_intelligence", return_value='{"result": "ok"}'
+            ):
                 result = run_task_from_file(coordinator, task_name="delegate")
 
         assert result["task"] == "delegate"
@@ -221,7 +246,9 @@ class TestRemoteDelegation:
             },
         }
 
-        with patch("oas_cli.runner._fetch_remote_spec", return_value=self_delegating_spec):
+        with patch(
+            "oas_cli.runner._fetch_remote_spec", return_value=self_delegating_spec
+        ):
             with pytest.raises(OARunError) as exc_info:
                 run_task_from_file(coordinator, task_name="delegate")
 
@@ -229,10 +256,17 @@ class TestRemoteDelegation:
 
     def test_remote_task_not_found_raises(self, tmp_path):
         p = tmp_path / "coordinator.yaml"
-        p.write_text(yaml.dump(_make_coordinator_spec("oa://prime-vector/summariser", "ghost_task")))
+        p.write_text(
+            yaml.dump(
+                _make_coordinator_spec("oa://prime-vector/summariser", "ghost_task")
+            )
+        )
         coordinator = p
 
-        with patch("oas_cli.runner._fetch_remote_spec", return_value=yaml.safe_load(_MINIMAL_SPEC_YAML)):
+        with patch(
+            "oas_cli.runner._fetch_remote_spec",
+            return_value=yaml.safe_load(_MINIMAL_SPEC_YAML),
+        ):
             with pytest.raises(OARunError) as exc_info:
                 run_task_from_file(coordinator, task_name="delegate")
 
@@ -242,7 +276,10 @@ class TestRemoteDelegation:
         """Smoke-test the bundled registry index."""
         index_path = (
             Path(__file__).parent.parent
-            / "Website" / "public" / "registry" / "index.json"
+            / "Website"
+            / "public"
+            / "registry"
+            / "index.json"
         )
         with index_path.open() as f:
             data = json.load(f)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,255 @@
+"""Tests for spec registry URL resolution and remote spec fetching.
+
+Covers:
+  - oa:// shorthand expansion (with and without @version)
+  - https:// pass-through
+  - Local path detection
+  - Remote spec fetching (mocked HTTP)
+  - Remote spec delegation in the runner (mocked)
+  - Cycle detection for remote specs
+  - Error cases: bad URL format, HTTP errors, invalid YAML
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from oas_cli.runner import (
+    _REGISTRY_BASE,
+    OARunError,
+    _fetch_remote_spec,
+    _is_remote_ref,
+    _resolve_spec_url,
+    run_task_from_file,
+)
+
+# ── URL resolution ────────────────────────────────────────────────────────────
+
+
+class TestResolveSpecUrl:
+    def test_oa_shorthand_no_version(self):
+        url = _resolve_spec_url("oa://prime-vector/summariser")
+        assert url == f"{_REGISTRY_BASE}/prime-vector/summariser/latest/spec.yaml"
+
+    def test_oa_shorthand_with_version(self):
+        url = _resolve_spec_url("oa://prime-vector/summariser@1.0.0")
+        assert url == f"{_REGISTRY_BASE}/prime-vector/summariser/1.0.0/spec.yaml"
+
+    def test_https_url_returned_as_is(self):
+        url = "https://example.com/my/spec.yaml"
+        assert _resolve_spec_url(url) == url
+
+    def test_http_url_returned_as_is(self):
+        url = "http://localhost:8080/spec.yaml"
+        assert _resolve_spec_url(url) == url
+
+    def test_oa_shorthand_wrong_segments_raises(self):
+        with pytest.raises(OARunError) as exc_info:
+            _resolve_spec_url("oa://too/many/parts/here")
+        assert exc_info.value.code == "SPEC_LOAD_ERROR"
+
+    def test_oa_shorthand_single_segment_raises(self):
+        with pytest.raises(OARunError) as exc_info:
+            _resolve_spec_url("oa://just-name")
+        assert exc_info.value.code == "SPEC_LOAD_ERROR"
+
+
+class TestIsRemoteRef:
+    def test_oa_scheme(self):
+        assert _is_remote_ref("oa://prime-vector/summariser") is True
+
+    def test_https_scheme(self):
+        assert _is_remote_ref("https://example.com/spec.yaml") is True
+
+    def test_http_scheme(self):
+        assert _is_remote_ref("http://localhost/spec.yaml") is True
+
+    def test_local_relative_path(self):
+        assert _is_remote_ref("./shared/spec.yaml") is False
+
+    def test_local_absolute_path(self):
+        assert _is_remote_ref("/Users/me/spec.yaml") is False
+
+
+# ── Remote spec fetching ──────────────────────────────────────────────────────
+
+
+def _make_mock_response(body: str, status: int = 200):
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body.encode("utf-8")
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+_MINIMAL_SPEC_YAML = yaml.dump(
+    {
+        "open_agent_spec": "1.4.0",
+        "agent": {"name": "test", "description": "test", "role": "analyst"},
+        "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o-mini"},
+        "tasks": {
+            "run": {
+                "description": "test task",
+                "input": {"type": "object", "properties": {}, "required": []},
+                "output": {
+                    "type": "object",
+                    "properties": {"result": {"type": "string"}},
+                    "required": ["result"],
+                },
+                "prompts": {"system": "s", "user": "u"},
+            }
+        },
+    }
+)
+
+
+class TestFetchRemoteSpec:
+    def test_successful_fetch(self):
+        with patch("urllib.request.urlopen", return_value=_make_mock_response(_MINIMAL_SPEC_YAML)):
+            spec = _fetch_remote_spec("https://example.com/spec.yaml")
+        assert spec["open_agent_spec"] == "1.4.0"
+        assert "tasks" in spec
+
+    def test_http_error_raises(self):
+        import urllib.error
+
+        with patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError(
+            url="https://example.com/spec.yaml",
+            code=404,
+            msg="Not Found",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )):
+            with pytest.raises(OARunError) as exc_info:
+                _fetch_remote_spec("https://example.com/spec.yaml")
+        assert exc_info.value.code == "SPEC_LOAD_ERROR"
+        assert "404" in str(exc_info.value)
+
+    def test_url_error_raises(self):
+        import urllib.error
+
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("connection refused")):
+            with pytest.raises(OARunError) as exc_info:
+                _fetch_remote_spec("https://example.com/spec.yaml")
+        assert exc_info.value.code == "SPEC_LOAD_ERROR"
+
+    def test_invalid_yaml_raises(self):
+        with patch("urllib.request.urlopen", return_value=_make_mock_response(":: not valid yaml ::")):
+            with pytest.raises(OARunError) as exc_info:
+                _fetch_remote_spec("https://example.com/spec.yaml")
+        assert exc_info.value.code == "SPEC_LOAD_ERROR"
+
+    def test_non_mapping_yaml_raises(self):
+        with patch("urllib.request.urlopen", return_value=_make_mock_response("- just\n- a\n- list\n")):
+            with pytest.raises(OARunError) as exc_info:
+                _fetch_remote_spec("https://example.com/spec.yaml")
+        assert exc_info.value.code == "SPEC_LOAD_ERROR"
+
+
+# ── Remote delegation in the runner ──────────────────────────────────────────
+
+
+def _make_coordinator_spec(spec_ref: str, task_ref: str = "run") -> dict:
+    return {
+        "open_agent_spec": "1.4.0",
+        "agent": {"name": "coordinator", "description": "test", "role": "analyst"},
+        "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o-mini"},
+        "prompts": {"system": "s", "user": "u"},
+        "tasks": {
+            "delegate": {
+                "description": "Delegated task",
+                "spec": spec_ref,
+                "task": task_ref,
+            }
+        },
+    }
+
+
+class TestRemoteDelegation:
+    def _write_coordinator(self, tmp_path: Path, spec_ref: str) -> Path:
+        p = tmp_path / "coordinator.yaml"
+        p.write_text(yaml.dump(_make_coordinator_spec(spec_ref)))
+        return p
+
+    def test_oa_url_delegation_executes_remote_spec(self, tmp_path):
+        coordinator = self._write_coordinator(tmp_path, "oa://prime-vector/summariser")
+
+        with patch("oas_cli.runner._fetch_remote_spec", return_value=yaml.safe_load(_MINIMAL_SPEC_YAML)):
+            with patch("oas_cli.runner.invoke_intelligence", return_value='{"result": "ok"}'):
+                result = run_task_from_file(coordinator, task_name="delegate")
+
+        assert result["task"] == "delegate"
+        assert "delegated_to" in result
+        assert "prime-vector/summariser" in result["delegated_to"]
+
+    def test_https_url_delegation_executes_remote_spec(self, tmp_path):
+        coordinator = self._write_coordinator(
+            tmp_path, "https://example.com/specs/myspec.yaml"
+        )
+
+        with patch("oas_cli.runner._fetch_remote_spec", return_value=yaml.safe_load(_MINIMAL_SPEC_YAML)):
+            with patch("oas_cli.runner.invoke_intelligence", return_value='{"result": "ok"}'):
+                result = run_task_from_file(coordinator, task_name="delegate")
+
+        assert result["task"] == "delegate"
+        assert "https://example.com" in result["delegated_to"]
+
+    def test_remote_cycle_detection(self, tmp_path):
+        """A remote spec that delegates back to the same URL raises DELEGATION_CYCLE_ERROR."""
+        remote_url = "https://example.com/cycle.yaml"
+
+        # Coordinator delegates to remote_url
+        coordinator = self._write_coordinator(tmp_path, remote_url)
+
+        # The remote spec also delegates to itself
+        self_delegating_spec = {
+            "open_agent_spec": "1.4.0",
+            "agent": {"name": "cyclic", "description": "cycles", "role": "analyst"},
+            "intelligence": {"type": "llm", "engine": "openai", "model": "gpt-4o-mini"},
+            "prompts": {"system": "s", "user": "u"},
+            "tasks": {
+                "run": {
+                    "description": "Self-delegating",
+                    "spec": remote_url,
+                    "task": "run",
+                }
+            },
+        }
+
+        with patch("oas_cli.runner._fetch_remote_spec", return_value=self_delegating_spec):
+            with pytest.raises(OARunError) as exc_info:
+                run_task_from_file(coordinator, task_name="delegate")
+
+        assert exc_info.value.code == "DELEGATION_CYCLE_ERROR"
+
+    def test_remote_task_not_found_raises(self, tmp_path):
+        p = tmp_path / "coordinator.yaml"
+        p.write_text(yaml.dump(_make_coordinator_spec("oa://prime-vector/summariser", "ghost_task")))
+        coordinator = p
+
+        with patch("oas_cli.runner._fetch_remote_spec", return_value=yaml.safe_load(_MINIMAL_SPEC_YAML)):
+            with pytest.raises(OARunError) as exc_info:
+                run_task_from_file(coordinator, task_name="delegate")
+
+        assert exc_info.value.code == "TASK_NOT_FOUND"
+
+    def test_registry_index_is_valid_json(self):
+        """Smoke-test the bundled registry index."""
+        index_path = (
+            Path(__file__).parent.parent
+            / "Website" / "public" / "registry" / "index.json"
+        )
+        with index_path.open() as f:
+            data = json.load(f)
+
+        assert "specs" in data
+        assert len(data["specs"]) >= 5
+        for spec in data["specs"]:
+            assert "id" in spec
+            assert "url" in spec
+            assert spec["url"].startswith("https://openagentspec.dev/registry/")


### PR DESCRIPTION
## Summary

Introduces the OA Spec Registry — a Docker Hub-style registry of reusable agent specs, served as static files from `openagentspec.dev/registry` (Vercel, no custom infrastructure). Adds `oa://` shorthand URL support to the runner so specs can be pulled and delegated to directly from YAML.

## Usage

```yaml
tasks:
  summarise:
    description: Delegates to the shared summariser from the registry
    spec: oa://prime-vector/summariser
    task: summarise

  review:
    description: Uses a pinned version
    spec: oa://prime-vector/code-reviewer@1.0.0
    task: review_code
```

Direct HTTPS URLs also work:
```yaml
spec: https://openagentspec.dev/registry/prime-vector/sentiment/latest/spec.yaml
```

## URL scheme

| Format | Resolves to |
|---|---|
| `oa://namespace/name` | `https://openagentspec.dev/registry/namespace/name/latest/spec.yaml` |
| `oa://namespace/name@1.0.0` | `https://openagentspec.dev/registry/namespace/name/1.0.0/spec.yaml` |
| `https://...` | passed through as-is (supports third-party registries) |

## Seed specs (all at `prime-vector/`)

| Spec | Task | Description |
|---|---|---|
| `summariser` | `summarise` | Summarise text + extract key points |
| `sentiment` | `analyse_sentiment` | Sentiment label + confidence + reasoning |
| `classifier` | `classify` | Classify into runtime-provided categories |
| `keyword-extractor` | `extract_keywords` | Keywords + phrases by relevance |
| `code-reviewer` | `review_code` | Bug/security/improvement review with severity ratings |

Each spec is available at `1.0.0` and `latest`.

## Implementation

- `oas_cli/runner.py`: `_resolve_spec_url()`, `_fetch_remote_spec()`, `_is_remote_ref()` — stdlib `urllib` only, no new dependencies
- Cycle detection works across remote URLs (URL string used as the visited-set key)
- `Website/public/registry/` — static files, `index.json` manifest
- `tests/test_registry.py` — 21 new tests

## Test plan
- [ ] `https://openagentspec.dev/registry/index.json` returns valid JSON after deploy
- [ ] `https://openagentspec.dev/registry/prime-vector/summariser/latest/spec.yaml` returns valid YAML
- [ ] `oa run` with `spec: oa://prime-vector/summariser` fetches and runs remotely
- [ ] `oa run` with `spec: oa://prime-vector/summariser@1.0.0` uses pinned version
- [ ] Cycle via remote URL raises `DELEGATION_CYCLE_ERROR`
- [ ] `pytest tests/test_registry.py` — 21 passed

Made with [Cursor](https://cursor.com)