### PR TITLE
fix(cli): --input accepts .json files + registry-demo example

### DIFF
--- a/examples/registry-demo/input.json
+++ b/examples/registry-demo/input.json
@@ -1,0 +1,3 @@
+{
+  "text": "Open Agent Spec defines AI agents declaratively in YAML. Agents are version-controlled, engine-agnostic, and portable across runtimes. The 1.4.0 release adds tool use, spec composition, and a test harness — all without introducing orchestration or framework dependencies. Tasks can now delegate to shared specialist specs in the OA registry using a single oa:// reference, enabling reuse across projects with no duplication."
+}

--- a/examples/registry-demo/pipeline.yaml
+++ b/examples/registry-demo/pipeline.yaml
@@ -1,0 +1,34 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: registry-demo
+  description: >
+    Demo pipeline that pulls two shared specialist specs directly from the
+    OA registry using the oa:// shorthand. No local copies — tasks are
+    delegated remotely at run time.
+  role: analyst
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+
+tasks:
+  # Step 1 — delegate to the shared summariser from the registry
+  summarise:
+    description: >
+      Summarise the provided text. Delegates to the prime-vector/summariser
+      spec from the OA registry.
+    spec: oa://prime-vector/summariser
+    task: summarise
+
+  # Step 2 — analyse the sentiment of the summary (depends on step 1)
+  sentiment_of_summary:
+    description: >
+      Analyse the sentiment of the summary produced in step 1. Delegates to
+      the prime-vector/sentiment spec. Receives the summary output via
+      depends_on — no manual wiring needed.
+    spec: oa://prime-vector/sentiment
+    task: analyse_sentiment
+    depends_on:
+      - summarise

--- a/examples/registry-demo/run.sh
+++ b/examples/registry-demo/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Registry demo — pulls two shared specs from the OA registry and runs them
+# as a two-step pipeline (summarise → sentiment_of_summary).
+#
+# Prerequisites:
+#   export OPENAI_API_KEY=sk-...
+#   pip install open-agent-spec   (or: pip install -e ../../)
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "=== Step 1: summarise (via oa://prime-vector/summariser) ==="
+oa run --spec pipeline.yaml --task summarise --input input.json | python3 -m json.tool
+
+echo ""
+echo "=== Full pipeline: summarise → sentiment_of_summary ==="
+oa run --spec pipeline.yaml --task sentiment_of_summary --input input.json | python3 -m json.tool

--- a/oas_cli/main.py
+++ b/oas_cli/main.py
@@ -634,32 +634,50 @@ def run(
         input_data: dict[str, Any] | None = None
         if input:
             input_stripped = input.strip()
-            # Convenience: if --input is a path to an existing file and the task
-            # has a single required string input, use file contents as that key.
+            # Convenience: if --input is a path to an existing file, either parse
+            # it as JSON (for .json files) or use its text content as the single
+            # required string input field (for plain text files such as diffs).
             if not input_stripped.startswith("{") and not input_stripped.startswith(
                 "["
             ):
                 input_path = Path(input_stripped).resolve()
                 if not input_path.is_file():
                     raise typer.BadParameter(f"File not found: {input_path}")
-                spec_data = _load_spec(spec)
-                _task_name, task_def = _choose_task(spec_data, task)
-                inp_schema = task_def.get("input") or {}
-                req = inp_schema.get("required") or []
-                props = inp_schema.get("properties") or {}
-                if len(req) != 1 or (props.get(req[0]) or {}).get("type") != "string":
-                    raise typer.BadParameter(
-                        "When --input is a file path, the task must have exactly "
-                        "one required string input (e.g. diff). Use JSON otherwise."
-                    )
-                content = input_path.read_text(encoding="utf-8")
-                if not content.strip():
-                    raise typer.BadParameter(
-                        f"File '{input_path.name}' is empty. "
-                        "Generate a diff first (e.g. make a change, then run "
-                        "'git diff > change.diff'), then run again."
-                    )
-                input_data = {req[0]: content}
+
+                # .json files are always parsed as a JSON object directly.
+                if input_path.suffix.lower() == ".json":
+                    try:
+                        input_data = json.loads(
+                            input_path.read_text(encoding="utf-8")
+                        )
+                    except json.JSONDecodeError as e:
+                        raise typer.BadParameter(
+                            f"Invalid JSON in '{input_path.name}': {e}"
+                        ) from e
+                    if not isinstance(input_data, dict):
+                        raise typer.BadParameter(
+                            f"'{input_path.name}' must contain a JSON object, not an array or scalar."
+                        )
+                else:
+                    # Plain text file — must map to a single required string input.
+                    spec_data = _load_spec(spec)
+                    _task_name, task_def = _choose_task(spec_data, task)
+                    inp_schema = task_def.get("input") or {}
+                    req = inp_schema.get("required") or []
+                    props = inp_schema.get("properties") or {}
+                    if len(req) != 1 or (props.get(req[0]) or {}).get("type") != "string":
+                        raise typer.BadParameter(
+                            "When --input is a file path, the task must have exactly "
+                            "one required string input (e.g. diff). Use JSON otherwise."
+                        )
+                    content = input_path.read_text(encoding="utf-8")
+                    if not content.strip():
+                        raise typer.BadParameter(
+                            f"File '{input_path.name}' is empty. "
+                            "Generate a diff first (e.g. make a change, then run "
+                            "'git diff > change.diff'), then run again."
+                        )
+                    input_data = {req[0]: content}
             else:
                 try:
                     parsed = json.loads(input)

--- a/tests/test_multi_task_workflows.py
+++ b/tests/test_multi_task_workflows.py
@@ -1056,6 +1056,97 @@ class TestCLIIntegration:
         assert result.exit_code == 0, result.output
         assert "Alice" in captured["prompt"]
 
+    def test_json_file_input_parsed_as_object(self, tmp_path, cli_spec_file):
+        """--input pointing to a .json file is parsed as a JSON object."""
+        input_file = tmp_path / "input.json"
+        input_file.write_text('{"name": "Alice"}')
+
+        captured: dict = {}
+
+        def fake_invoke(system: str, user: str, config: dict) -> str:
+            captured["prompt"] = f"{system}\n\n{user}"
+            return '{"response": "hi"}'
+
+        with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
+            result = cli.invoke(
+                app,
+                [
+                    "run",
+                    "--spec",
+                    str(cli_spec_file),
+                    "--task",
+                    "greet",
+                    "--input",
+                    str(input_file),
+                    "--quiet",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Alice" in captured["prompt"]
+
+    def test_json_file_input_multi_field(self, tmp_path, cli_spec_file):
+        """A .json file with multiple fields is accepted even for multi-field tasks."""
+        input_file = tmp_path / "data.json"
+        input_file.write_text('{"name": "Bob", "extra": "ignored"}')
+
+        with patch("oas_cli.runner.invoke_intelligence", return_value='{"response": "ok"}'):
+            result = cli.invoke(
+                app,
+                [
+                    "run",
+                    "--spec",
+                    str(cli_spec_file),
+                    "--task",
+                    "greet",
+                    "--input",
+                    str(input_file),
+                    "--quiet",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+
+    def test_json_file_input_invalid_json_exits_nonzero(self, tmp_path, cli_spec_file):
+        """A .json file containing invalid JSON exits with a non-zero code."""
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("not valid json {{{")
+
+        result = cli.invoke(
+            app,
+            [
+                "run",
+                "--spec",
+                str(cli_spec_file),
+                "--task",
+                "greet",
+                "--input",
+                str(bad_file),
+            ],
+        )
+
+        assert result.exit_code != 0
+
+    def test_json_file_input_array_exits_nonzero(self, tmp_path, cli_spec_file):
+        """A .json file containing a JSON array (not an object) exits with a non-zero code."""
+        array_file = tmp_path / "array.json"
+        array_file.write_text('[{"name": "Alice"}]')
+
+        result = cli.invoke(
+            app,
+            [
+                "run",
+                "--spec",
+                str(cli_spec_file),
+                "--task",
+                "greet",
+                "--input",
+                str(array_file),
+            ],
+        )
+
+        assert result.exit_code != 0
+
     def test_system_prompt_on_bye_task(self, cli_spec_file):
         result = _cli_run(
             cli_spec_file,


### PR DESCRIPTION
## Summary

- **`fix(cli)`**: `--input <file>.json` now parses the file as a JSON object directly, so `oa run --spec pipeline.yaml --task summarise --input input.json` works as expected. Plain text files (diffs etc.) continue to work as before.
- **`feat(examples)`**: `examples/registry-demo/` — a two-task pipeline using `oa://prime-vector/summariser` and `oa://prime-vector/sentiment` from the registry, with a sample `input.json` and `run.sh`.
- **`test(cli)`**: 4 new tests covering `.json` file input — valid object, multi-field, invalid JSON, and JSON array (should error).

## Behaviour change

| `--input` value | Before | After |
|---|---|---|
| `input.json` (file, multi-field) | ❌ error — single-string only | ✅ parsed as JSON object |
| `input.json` (file, single-field) | ❌ error — single-string only | ✅ parsed as JSON object |
| `change.diff` (file, single-field) | ✅ content → field | ✅ unchanged |
| `'{"key":"val"}'` (inline JSON) | ✅ | ✅ unchanged |

## Test plan
- [ ] `pytest tests/test_multi_task_workflows.py -k json_file_input` — 4 passed
- [ ] `cd examples/registry-demo && oa run --spec pipeline.yaml --task summarise --input input.json`

Made with [Cursor](https://cursor.com)