### PR TITLE
feat: add history threading and memory-retriever registry spec

### DIFF
--- a/Website/public/registry/index.json
+++ b/Website/public/registry/index.json
@@ -67,6 +67,19 @@
       "usage": "spec: oa://prime-vector/code-reviewer",
       "task": "review_code",
       "url": "https://openagentspec.dev/registry/prime-vector/code-reviewer/latest/spec.yaml"
+    },
+    {
+      "id": "prime-vector/memory-retriever",
+      "name": "Memory Retriever",
+      "description": "Retrieve semantically relevant prior conversation turns from an external store and return them as a history context block ready to pass to any chat-capable OAS task.",
+      "namespace": "prime-vector",
+      "slug": "memory-retriever",
+      "latest": "1.0.0",
+      "versions": ["1.0.0"],
+      "tags": ["memory", "chat", "context", "retrieval"],
+      "usage": "spec: oa://prime-vector/memory-retriever",
+      "task": "retrieve",
+      "url": "https://openagentspec.dev/registry/prime-vector/memory-retriever/latest/spec.yaml"
     }
   ]
 }

--- a/Website/public/registry/prime-vector/memory-retriever/1.0.0/spec.yaml
+++ b/Website/public/registry/prime-vector/memory-retriever/1.0.0/spec.yaml
@@ -3,12 +3,19 @@ open_agent_spec: "1.4.0"
 agent:
   name: memory-retriever
   description: >
-    Retrieve semantically relevant memories from an external store and format
-    them as a conversation-history context block.  The agent accepts a query
-    and an optional memory_store_url, calls the store's search endpoint, and
-    returns a list of prior turns (role + content) that the calling spec injects
-    into its own `history` input.  OAS never stores or manages memory — this
-    spec is purely a retrieval interface.
+    LLM-powered memory re-ranker.  Your application fetches raw candidate
+    turns from an external store (vector DB, Redis, SQLite FTS, etc.) and
+    passes them in as `candidates`.  This spec uses the LLM to select the
+    most contextually relevant turns, re-order them oldest-first, and return
+    them as a `history` array ready to inject into any chat-capable OAS task.
+
+    OAS never stores or manages memory — the store is external infrastructure.
+    This spec is purely a re-ranking interface between your store and the model.
+
+    Typical pipeline usage:
+      1. Application fetches top-N candidates from your memory store.
+      2. Delegate to this spec — pass `query` and `candidates`.
+      3. Use `depends_on` to feed the returned `history` into a chat task.
   role: memory
 
 intelligence:
@@ -21,32 +28,42 @@ intelligence:
 tasks:
   retrieve:
     description: >
-      Search the memory store for turns relevant to `query` and return them
-      as a `history` array ready to pass to any chat-capable OAS task.
+      Re-rank and filter `candidates` to return only the turns most relevant
+      to `query`, ordered oldest-first as a `history` array.
     input:
       type: object
       properties:
         query:
           type: string
           description: The user's current message or search phrase.
-        memory_store_url:
-          type: string
+        candidates:
+          type: array
           description: >
-            Base URL of the memory store's search endpoint.
-            Defaults to http://localhost:8765 when omitted.
+            Raw candidate turns fetched from your memory store.
+            Each item must have `role` ("user" or "assistant") and `content`.
+          items:
+            type: object
+            properties:
+              role:
+                type: string
+                enum: [user, assistant]
+              content:
+                type: string
+            required: [role, content]
         top_k:
           type: integer
           description: Maximum number of prior turns to return (default 5).
       required:
         - query
+        - candidates
     output:
       type: object
       properties:
         history:
           type: array
           description: >
-            Prior conversation turns relevant to the query, ordered oldest-first.
-            Each item is {"role": "user"|"assistant", "content": "…"}.
+            The most relevant prior turns, ordered oldest-first, ready to
+            pass as `history` input to any OAS chat task.
           items:
             type: object
             properties:
@@ -58,25 +75,24 @@ tasks:
             required: [role, content]
         memory_count:
           type: integer
-          description: Total number of turns returned.
+          description: Number of turns returned in `history`.
       required:
         - history
         - memory_count
     prompts:
       system: >
-        You are a memory retrieval assistant.  Your job is to select which prior
-        conversation turns are most relevant to the user's current query and
-        return them in chronological order.  You MUST respond with valid JSON
-        only — no prose, no markdown fences.
+        You are a memory re-ranking assistant.  Select the conversation turns
+        most relevant to the user's current message, re-order them
+        oldest-first, and return valid JSON only — no prose, no markdown.
       user: |
-        The user's current message is:
+        Current user message:
         "{query}"
 
-        The memory store returned the following candidate turns (newest first):
-        {memory_store_results}
+        Candidate prior turns (may be in any order):
+        {candidates}
 
-        Select the {top_k_effective} most relevant turns, re-order them
-        oldest-first, and return:
+        Return up to {top_k} of the most relevant turns, oldest-first.
+        Respond with JSON only:
         {
           "history": [
             {"role": "user"|"assistant", "content": "…"},

--- a/Website/public/registry/prime-vector/memory-retriever/1.0.0/spec.yaml
+++ b/Website/public/registry/prime-vector/memory-retriever/1.0.0/spec.yaml
@@ -1,0 +1,86 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: memory-retriever
+  description: >
+    Retrieve semantically relevant memories from an external store and format
+    them as a conversation-history context block.  The agent accepts a query
+    and an optional memory_store_url, calls the store's search endpoint, and
+    returns a list of prior turns (role + content) that the calling spec injects
+    into its own `history` input.  OAS never stores or manages memory — this
+    spec is purely a retrieval interface.
+  role: memory
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.0
+
+tasks:
+  retrieve:
+    description: >
+      Search the memory store for turns relevant to `query` and return them
+      as a `history` array ready to pass to any chat-capable OAS task.
+    input:
+      type: object
+      properties:
+        query:
+          type: string
+          description: The user's current message or search phrase.
+        memory_store_url:
+          type: string
+          description: >
+            Base URL of the memory store's search endpoint.
+            Defaults to http://localhost:8765 when omitted.
+        top_k:
+          type: integer
+          description: Maximum number of prior turns to return (default 5).
+      required:
+        - query
+    output:
+      type: object
+      properties:
+        history:
+          type: array
+          description: >
+            Prior conversation turns relevant to the query, ordered oldest-first.
+            Each item is {"role": "user"|"assistant", "content": "…"}.
+          items:
+            type: object
+            properties:
+              role:
+                type: string
+                enum: [user, assistant]
+              content:
+                type: string
+            required: [role, content]
+        memory_count:
+          type: integer
+          description: Total number of turns returned.
+      required:
+        - history
+        - memory_count
+    prompts:
+      system: >
+        You are a memory retrieval assistant.  Your job is to select which prior
+        conversation turns are most relevant to the user's current query and
+        return them in chronological order.  You MUST respond with valid JSON
+        only — no prose, no markdown fences.
+      user: |
+        The user's current message is:
+        "{query}"
+
+        The memory store returned the following candidate turns (newest first):
+        {memory_store_results}
+
+        Select the {top_k_effective} most relevant turns, re-order them
+        oldest-first, and return:
+        {
+          "history": [
+            {"role": "user"|"assistant", "content": "…"},
+            …
+          ],
+          "memory_count": <integer>
+        }

--- a/Website/public/registry/prime-vector/memory-retriever/latest/spec.yaml
+++ b/Website/public/registry/prime-vector/memory-retriever/latest/spec.yaml
@@ -3,12 +3,19 @@ open_agent_spec: "1.4.0"
 agent:
   name: memory-retriever
   description: >
-    Retrieve semantically relevant memories from an external store and format
-    them as a conversation-history context block.  The agent accepts a query
-    and an optional memory_store_url, calls the store's search endpoint, and
-    returns a list of prior turns (role + content) that the calling spec injects
-    into its own `history` input.  OAS never stores or manages memory — this
-    spec is purely a retrieval interface.
+    LLM-powered memory re-ranker.  Your application fetches raw candidate
+    turns from an external store (vector DB, Redis, SQLite FTS, etc.) and
+    passes them in as `candidates`.  This spec uses the LLM to select the
+    most contextually relevant turns, re-order them oldest-first, and return
+    them as a `history` array ready to inject into any chat-capable OAS task.
+
+    OAS never stores or manages memory — the store is external infrastructure.
+    This spec is purely a re-ranking interface between your store and the model.
+
+    Typical pipeline usage:
+      1. Application fetches top-N candidates from your memory store.
+      2. Delegate to this spec — pass `query` and `candidates`.
+      3. Use `depends_on` to feed the returned `history` into a chat task.
   role: memory
 
 intelligence:
@@ -21,32 +28,42 @@ intelligence:
 tasks:
   retrieve:
     description: >
-      Search the memory store for turns relevant to `query` and return them
-      as a `history` array ready to pass to any chat-capable OAS task.
+      Re-rank and filter `candidates` to return only the turns most relevant
+      to `query`, ordered oldest-first as a `history` array.
     input:
       type: object
       properties:
         query:
           type: string
           description: The user's current message or search phrase.
-        memory_store_url:
-          type: string
+        candidates:
+          type: array
           description: >
-            Base URL of the memory store's search endpoint.
-            Defaults to http://localhost:8765 when omitted.
+            Raw candidate turns fetched from your memory store.
+            Each item must have `role` ("user" or "assistant") and `content`.
+          items:
+            type: object
+            properties:
+              role:
+                type: string
+                enum: [user, assistant]
+              content:
+                type: string
+            required: [role, content]
         top_k:
           type: integer
           description: Maximum number of prior turns to return (default 5).
       required:
         - query
+        - candidates
     output:
       type: object
       properties:
         history:
           type: array
           description: >
-            Prior conversation turns relevant to the query, ordered oldest-first.
-            Each item is {"role": "user"|"assistant", "content": "…"}.
+            The most relevant prior turns, ordered oldest-first, ready to
+            pass as `history` input to any OAS chat task.
           items:
             type: object
             properties:
@@ -58,25 +75,24 @@ tasks:
             required: [role, content]
         memory_count:
           type: integer
-          description: Total number of turns returned.
+          description: Number of turns returned in `history`.
       required:
         - history
         - memory_count
     prompts:
       system: >
-        You are a memory retrieval assistant.  Your job is to select which prior
-        conversation turns are most relevant to the user's current query and
-        return them in chronological order.  You MUST respond with valid JSON
-        only — no prose, no markdown fences.
+        You are a memory re-ranking assistant.  Select the conversation turns
+        most relevant to the user's current message, re-order them
+        oldest-first, and return valid JSON only — no prose, no markdown.
       user: |
-        The user's current message is:
+        Current user message:
         "{query}"
 
-        The memory store returned the following candidate turns (newest first):
-        {memory_store_results}
+        Candidate prior turns (may be in any order):
+        {candidates}
 
-        Select the {top_k_effective} most relevant turns, re-order them
-        oldest-first, and return:
+        Return up to {top_k} of the most relevant turns, oldest-first.
+        Respond with JSON only:
         {
           "history": [
             {"role": "user"|"assistant", "content": "…"},

--- a/Website/public/registry/prime-vector/memory-retriever/latest/spec.yaml
+++ b/Website/public/registry/prime-vector/memory-retriever/latest/spec.yaml
@@ -1,0 +1,86 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: memory-retriever
+  description: >
+    Retrieve semantically relevant memories from an external store and format
+    them as a conversation-history context block.  The agent accepts a query
+    and an optional memory_store_url, calls the store's search endpoint, and
+    returns a list of prior turns (role + content) that the calling spec injects
+    into its own `history` input.  OAS never stores or manages memory — this
+    spec is purely a retrieval interface.
+  role: memory
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.0
+
+tasks:
+  retrieve:
+    description: >
+      Search the memory store for turns relevant to `query` and return them
+      as a `history` array ready to pass to any chat-capable OAS task.
+    input:
+      type: object
+      properties:
+        query:
+          type: string
+          description: The user's current message or search phrase.
+        memory_store_url:
+          type: string
+          description: >
+            Base URL of the memory store's search endpoint.
+            Defaults to http://localhost:8765 when omitted.
+        top_k:
+          type: integer
+          description: Maximum number of prior turns to return (default 5).
+      required:
+        - query
+    output:
+      type: object
+      properties:
+        history:
+          type: array
+          description: >
+            Prior conversation turns relevant to the query, ordered oldest-first.
+            Each item is {"role": "user"|"assistant", "content": "…"}.
+          items:
+            type: object
+            properties:
+              role:
+                type: string
+                enum: [user, assistant]
+              content:
+                type: string
+            required: [role, content]
+        memory_count:
+          type: integer
+          description: Total number of turns returned.
+      required:
+        - history
+        - memory_count
+    prompts:
+      system: >
+        You are a memory retrieval assistant.  Your job is to select which prior
+        conversation turns are most relevant to the user's current query and
+        return them in chronological order.  You MUST respond with valid JSON
+        only — no prose, no markdown fences.
+      user: |
+        The user's current message is:
+        "{query}"
+
+        The memory store returned the following candidate turns (newest first):
+        {memory_store_results}
+
+        Select the {top_k_effective} most relevant turns, re-order them
+        oldest-first, and return:
+        {
+          "history": [
+            {"role": "user"|"assistant", "content": "…"},
+            …
+          ],
+          "memory_count": <integer>
+        }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -619,6 +619,96 @@ This repository's own `.agents/` directory contains four specs used for developm
 
 ---
 
+## Memory management
+
+OAS is **stateless by design** — it never stores, summarises, or manages
+conversation history.  This keeps specs portable and infrastructure-agnostic.
+Two patterns cover the common memory use-cases without breaking that boundary.
+
+### Pattern 1 — Short-term history (within a session)
+
+Pass prior turns as the reserved `history` input field.  The runner
+automatically injects them between the system prompt and the current user
+message before calling the model.  Your application code manages the list;
+OAS just forwards it.
+
+```yaml
+tasks:
+  chat:
+    input:
+      type: object
+      properties:
+        message:  { type: string }
+        history:
+          type: array
+          description: >
+            Prior turns — [{"role": "user"|"assistant", "content": "…"}, …].
+            Injected by the runner automatically. OAS never writes to this field.
+          items:
+            type: object
+            properties:
+              role:    { type: string, enum: [user, assistant] }
+              content: { type: string }
+      required: [message]
+```
+
+Caller example (Python):
+
+```python
+history = []
+
+while True:
+    message = input("You: ")
+    result = run_task(spec_path, "chat", {"message": message, "history": history})
+    reply = result["reply"]
+    print(f"Agent: {reply}")
+
+    history.append({"role": "user",      "content": message})
+    history.append({"role": "assistant", "content": reply})
+```
+
+See [`examples/chat-agent/`](../examples/chat-agent/) for a full working example.
+
+### Pattern 2 — Long-term memory (across sessions)
+
+Use the `oa://prime-vector/memory-retriever` registry spec as a first task
+in a pipeline.  It calls your external memory store, retrieves relevant prior
+turns, and returns them as a `history` array.  A downstream `chat` task picks
+that up via `depends_on`.
+
+```yaml
+tasks:
+  recall:
+    spec: oa://prime-vector/memory-retriever
+    task: retrieve
+
+  respond:
+    depends_on: [recall]
+    spec: ../chat-agent/spec.yaml
+    task: chat
+```
+
+The runner merges `recall`'s output (including `history`) into `respond`'s
+input automatically — no glue code required.
+
+Your memory store is external infrastructure (vector DB, Redis, SQLite with
+semantic search, etc.) — OAS is not opinionated about the store technology,
+only about the retrieval interface.
+
+See [`examples/memory-chat/`](../examples/memory-chat/) for a complete
+pipeline spec and a minimal mock memory-store script.
+
+### What OAS deliberately does NOT do
+
+| Capability | Where it belongs |
+|---|---|
+| Session persistence | Your application / infrastructure |
+| History summarisation | A dedicated summarisation spec (`oa://prime-vector/summariser`) |
+| Memory write / upsert | Your memory store's write endpoint |
+| Branching on memory content | Outside OAS (OAS has no conditionals) |
+
+---
+
 ## Generated project layout
 
 ```

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -671,32 +671,38 @@ See [`examples/chat-agent/`](../examples/chat-agent/) for a full working example
 
 ### Pattern 2 — Long-term memory (across sessions)
 
-Use the `oa://prime-vector/memory-retriever` registry spec as a first task
-in a pipeline.  It calls your external memory store, retrieves relevant prior
-turns, and returns them as a `history` array.  A downstream `chat` task picks
-that up via `depends_on`.
+OAS specs are pure LLM interfaces — they cannot make HTTP calls during prompt
+rendering.  The long-term memory pattern therefore has two distinct layers:
+
+| Layer | Owner | Responsibility |
+|---|---|---|
+| Memory **store** | Your infrastructure | Persist, index, and search prior turns |
+| Memory **re-ranker** | `oa://prime-vector/memory-retriever` | Use the LLM to select the most relevant candidates |
+
+Your application code fetches raw candidate turns from the store, then passes
+them as the `candidates` input field.  The `memory-retriever` spec uses the
+LLM to re-rank and select the most relevant ones, returning a `history` array
+ready for `depends_on` chaining.
 
 ```yaml
 tasks:
   recall:
     spec: oa://prime-vector/memory-retriever
     task: retrieve
+    # input: { query, candidates: [...pre-fetched turns], top_k }
 
   respond:
     depends_on: [recall]
     spec: ../chat-agent/spec.yaml
     task: chat
+    # history from recall is merged in automatically
 ```
 
 The runner merges `recall`'s output (including `history`) into `respond`'s
-input automatically — no glue code required.
+input automatically — no glue code required in the spec.
 
-Your memory store is external infrastructure (vector DB, Redis, SQLite with
-semantic search, etc.) — OAS is not opinionated about the store technology,
-only about the retrieval interface.
-
-See [`examples/memory-chat/`](../examples/memory-chat/) for a complete
-pipeline spec and a minimal mock memory-store script.
+See [`examples/memory-chat/`](../examples/memory-chat/) for a runnable
+pipeline with a pre-populated `candidates` input.
 
 ### What OAS deliberately does NOT do
 

--- a/examples/chat-agent/chat.py
+++ b/examples/chat-agent/chat.py
@@ -24,15 +24,13 @@ examples/memory-chat/ for that pattern.
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
 # Allow running directly from repo root without `pip install -e .`
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from oas_cli.runner import run_task  # noqa: E402
-
+from oas_cli.runner import run_task
 
 SPEC_PATH = Path(__file__).parent / "spec.yaml"
 

--- a/examples/chat-agent/chat.py
+++ b/examples/chat-agent/chat.py
@@ -1,0 +1,71 @@
+"""Multi-turn chat loop demonstrating OAS history threading.
+
+Usage:
+    python examples/chat-agent/chat.py
+
+How it works
+------------
+OAS is stateless — it never stores conversation history.
+This script maintains the `history` list and passes it back on every
+invocation as a plain JSON input field.  The runner injects it between
+the system prompt and the current user message before calling the model.
+
+The pattern is:
+1. User types a message.
+2. Build input_data = {"message": ..., "history": [...prior turns...]}
+3. Call oa.run_task(spec_path, "chat", input_data)
+4. Append the user turn and the assistant reply to history.
+5. Repeat.
+
+Memory across sessions is out of scope for OAS.  For long-term memory,
+delegate a retrieval step to oa://prime-vector/memory-retriever — see
+examples/memory-chat/ for that pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Allow running directly from repo root without `pip install -e .`
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from oas_cli.runner import run_task  # noqa: E402
+
+
+SPEC_PATH = Path(__file__).parent / "spec.yaml"
+
+
+def main() -> None:
+    history: list[dict] = []
+
+    print("OAS chat-agent  (type 'quit' to exit)\n")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nBye!")
+            break
+
+        if not user_input or user_input.lower() in {"quit", "exit", "q"}:
+            print("Bye!")
+            break
+
+        input_data: dict = {"message": user_input}
+        if history:
+            input_data["history"] = history
+
+        result = run_task(SPEC_PATH, "chat", input_data)
+        reply: str = result.get("reply", "")
+
+        print(f"Agent: {reply}\n")
+
+        # Append completed turn to history for the next call.
+        history.append({"role": "user", "content": user_input})
+        history.append({"role": "assistant", "content": reply})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/chat-agent/spec.yaml
+++ b/examples/chat-agent/spec.yaml
@@ -1,0 +1,67 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: chat-agent
+  description: >
+    A stateless conversational assistant that accepts an optional `history`
+    input.  OAS never stores history — the caller appends each completed turn
+    and passes the array back on the next invocation.  This keeps the spec
+    purely declarative and infrastructure-agnostic.
+  role: assistant
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+  config:
+    temperature: 0.7
+    max_tokens: 1024
+
+tasks:
+  chat:
+    description: >
+      Reply to the user's message, taking previous conversation turns into
+      account when provided via the `history` input.
+    input:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The user's current message.
+        history:
+          type: array
+          description: >
+            Prior conversation turns in OpenAI wire format
+            [{"role": "user"|"assistant", "content": "…"}, …].
+            When provided, the runner injects them between the system prompt
+            and the current user message before calling the model.
+            OAS never writes to or manages this field.
+          items:
+            type: object
+            properties:
+              role:
+                type: string
+                enum: [user, assistant]
+              content:
+                type: string
+            required: [role, content]
+      required:
+        - message
+    output:
+      type: object
+      properties:
+        reply:
+          type: string
+          description: The assistant's reply to the user's message.
+      required:
+        - reply
+    prompts:
+      system: >
+        You are a helpful, friendly assistant.  You have access to previous
+        conversation turns which the runner injects automatically — use them
+        to maintain context.  Always reply in valid JSON.
+      user: |
+        {message}
+
+        Respond with JSON:
+        {"reply": "<your response>"}

--- a/examples/memory-chat/README.md
+++ b/examples/memory-chat/README.md
@@ -1,12 +1,28 @@
 # memory-chat
 
-Demonstrates how to combine **long-term memory retrieval** with a
+Demonstrates how to combine **LLM-powered memory re-ranking** with a
 **stateless chat reply** using OAS spec composition.
+
+## How it works
+
+OAS specs are pure LLM interfaces — they cannot make HTTP calls to external
+services during prompt rendering.  The memory pattern therefore has two
+distinct layers:
+
+| Layer | Owner | Responsibility |
+|---|---|---|
+| Memory **store** | Your infrastructure | Persist, index, and search prior turns |
+| Memory **re-ranker** | `oa://prime-vector/memory-retriever` | Use the LLM to select the most relevant candidates |
+
+Your application code fetches raw candidates from the store (however you
+like — vector similarity, keyword search, recency, etc.) and passes them in
+as the `candidates` input field.  The LLM then re-ranks them and returns
+only the most contextually relevant turns as a `history` array.
 
 ## Architecture
 
 ```
-input: { message, memory_store_url, top_k }
+input: { message, candidates: [...pre-fetched turns], top_k }
          │
          ▼
    ┌─────────────────────────────────────────────────┐
@@ -14,7 +30,8 @@ input: { message, memory_store_url, top_k }
    │  spec: oa://prime-vector/memory-retriever       │
    │  task: retrieve                                 │
    │                                                 │
-   │  Calls your memory store's search endpoint.     │
+   │  LLM re-ranks candidates, returns top_k most   │
+   │  relevant turns oldest-first.                   │
    │  Returns: { history: [...turns], memory_count } │
    └────────────────────┬────────────────────────────┘
                         │ depends_on (data merge)
@@ -25,47 +42,51 @@ input: { message, memory_store_url, top_k }
    │  task: chat                                     │
    │                                                 │
    │  Receives: { message, history: [...] }          │
-   │  The runner injects history between system      │
-   │  prompt and current user message automatically. │
+   │  Runner injects history between system prompt   │
+   │  and current user message automatically.        │
    │  Returns: { reply }                             │
    └─────────────────────────────────────────────────┘
 ```
 
-## Key principle
-
-OAS is **stateless**.  Memory lives in your infrastructure (a vector DB,
-Redis, a simple SQLite store — anything with an HTTP search endpoint).
-The `memory-retriever` spec is just a declarative interface to it.
-
 ## Running the pipeline
 
 ```bash
-# Requires a memory store running at http://localhost:8765
-# (see below for a minimal mock)
 oa run examples/memory-chat/pipeline.yaml respond \
   --input examples/memory-chat/input.json
 ```
 
-## Minimal memory store mock (for testing)
+The `input.json` file contains sample `candidates` (turns pre-fetched from
+a hypothetical memory store) so the pipeline runs end-to-end without needing
+a real store.
+
+## Plugging in a real memory store
+
+Replace `candidates` in the input with the results of a search against your
+store.  Any HTTP-accessible store works — the fetch happens in your
+application code before calling `oa run`:
 
 ```python
-# mock_memory_store.py — serves a static search result
-from http.server import BaseHTTPRequestHandler, HTTPServer
-import json
+import httpx, json
+from oas_cli.runner import run_task_from_file
 
-MEMORIES = [
-    {"role": "user",      "content": "The project deadline was moved to Q3."},
-    {"role": "assistant", "content": "Noted — I've updated the timeline."},
-]
+# 1. Fetch candidates from your store
+resp = httpx.post("http://localhost:8765/search", json={"query": message, "top_n": 10})
+candidates = resp.json()["results"]   # [{role, content}, ...]
 
-class Handler(BaseHTTPRequestHandler):
-    def do_POST(self):
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.end_headers()
-        self.wfile.write(json.dumps({"results": MEMORIES}).encode())
-
-HTTPServer(("localhost", 8765), Handler).serve_forever()
+# 2. Run the pipeline — OAS handles the rest
+result = run_task_from_file(
+    "examples/memory-chat/pipeline.yaml",
+    task_name="respond",
+    input_data={"message": message, "candidates": candidates, "top_k": 5},
+)
+print(result["output"]["reply"])
 ```
 
-Run with `python mock_memory_store.py`, then run the pipeline above.
+## What OAS deliberately does NOT do
+
+| Capability | Where it belongs |
+|---|---|
+| Fetching from the memory store | Your application code |
+| Writing / upserting memories | Your application code |
+| Session persistence | Your infrastructure |
+| History summarisation | `oa://prime-vector/summariser` |

--- a/examples/memory-chat/README.md
+++ b/examples/memory-chat/README.md
@@ -1,0 +1,71 @@
+# memory-chat
+
+Demonstrates how to combine **long-term memory retrieval** with a
+**stateless chat reply** using OAS spec composition.
+
+## Architecture
+
+```
+input: { message, memory_store_url, top_k }
+         │
+         ▼
+   ┌─────────────────────────────────────────────────┐
+   │  Task: recall                                   │
+   │  spec: oa://prime-vector/memory-retriever       │
+   │  task: retrieve                                 │
+   │                                                 │
+   │  Calls your memory store's search endpoint.     │
+   │  Returns: { history: [...turns], memory_count } │
+   └────────────────────┬────────────────────────────┘
+                        │ depends_on (data merge)
+                        ▼
+   ┌─────────────────────────────────────────────────┐
+   │  Task: respond                                  │
+   │  spec: ../chat-agent/spec.yaml                  │
+   │  task: chat                                     │
+   │                                                 │
+   │  Receives: { message, history: [...] }          │
+   │  The runner injects history between system      │
+   │  prompt and current user message automatically. │
+   │  Returns: { reply }                             │
+   └─────────────────────────────────────────────────┘
+```
+
+## Key principle
+
+OAS is **stateless**.  Memory lives in your infrastructure (a vector DB,
+Redis, a simple SQLite store — anything with an HTTP search endpoint).
+The `memory-retriever` spec is just a declarative interface to it.
+
+## Running the pipeline
+
+```bash
+# Requires a memory store running at http://localhost:8765
+# (see below for a minimal mock)
+oa run examples/memory-chat/pipeline.yaml respond \
+  --input examples/memory-chat/input.json
+```
+
+## Minimal memory store mock (for testing)
+
+```python
+# mock_memory_store.py — serves a static search result
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+
+MEMORIES = [
+    {"role": "user",      "content": "The project deadline was moved to Q3."},
+    {"role": "assistant", "content": "Noted — I've updated the timeline."},
+]
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"results": MEMORIES}).encode())
+
+HTTPServer(("localhost", 8765), Handler).serve_forever()
+```
+
+Run with `python mock_memory_store.py`, then run the pipeline above.

--- a/examples/memory-chat/input.json
+++ b/examples/memory-chat/input.json
@@ -1,5 +1,12 @@
 {
   "message": "What did we talk about last time regarding the project timeline?",
-  "memory_store_url": "http://localhost:8765",
-  "top_k": 5
+  "candidates": [
+    {"role": "user",      "content": "We need to decide on the project timeline."},
+    {"role": "assistant", "content": "I'd suggest targeting Q3 for the initial release."},
+    {"role": "user",      "content": "What about the API design review?"},
+    {"role": "assistant", "content": "The API review is scheduled for next week."},
+    {"role": "user",      "content": "Can we move the deadline to Q2?"},
+    {"role": "assistant", "content": "Q2 is very tight — let's keep Q3 as the target."}
+  ],
+  "top_k": 3
 }

--- a/examples/memory-chat/input.json
+++ b/examples/memory-chat/input.json
@@ -1,0 +1,5 @@
+{
+  "message": "What did we talk about last time regarding the project timeline?",
+  "memory_store_url": "http://localhost:8765",
+  "top_k": 5
+}

--- a/examples/memory-chat/pipeline.yaml
+++ b/examples/memory-chat/pipeline.yaml
@@ -3,19 +3,18 @@ open_agent_spec: "1.4.0"
 agent:
   name: memory-chat-pipeline
   description: >
-    Two-task pipeline combining long-term memory retrieval with a chat reply.
+    Two-task pipeline: LLM re-ranks pre-fetched memory candidates, then
+    replies to the user with the selected context injected as history.
 
-    1. `recall`  — delegates to oa://prime-vector/memory-retriever to search
-       the external memory store for turns relevant to the user's message.
-       Returns `history` and `memory_count`.
+    Your application code fetches raw candidates from the memory store and
+    passes them in as `candidates`.  OAS never touches the store directly.
 
-    2. `respond` — delegates to the local chat-agent spec.  It depends_on
-       `recall`, so the runner merges recall's output (including `history`)
-       into respond's input automatically before the model is called.
+    1. `recall`  — delegates to oa://prime-vector/memory-retriever.
+       Takes `query` and `candidates`; returns `history` and `memory_count`.
 
-    OAS never stores or manages memory — the memory store is external
-    infrastructure.  This spec is purely a declarative retrieval + reply
-    pipeline.
+    2. `respond` — delegates to the local chat-agent spec.
+       depends_on `recall` so the runner merges `history` into its input
+       automatically before calling the model.
   role: assistant
 
 intelligence:
@@ -25,13 +24,15 @@ intelligence:
 
 tasks:
   recall:
-    description: Retrieve relevant memory context for the user's message.
+    description: >
+      Re-rank pre-fetched memory candidates and return the most relevant
+      turns as a history array.
     spec: oa://prime-vector/memory-retriever
     task: retrieve
 
   respond:
     description: >
-      Reply to the user's message using retrieved memory context.
+      Reply to the user's message using the retrieved history context.
       The `history` field from `recall` is merged in automatically.
     depends_on:
       - recall

--- a/examples/memory-chat/pipeline.yaml
+++ b/examples/memory-chat/pipeline.yaml
@@ -1,0 +1,39 @@
+open_agent_spec: "1.4.0"
+
+agent:
+  name: memory-chat-pipeline
+  description: >
+    Two-task pipeline combining long-term memory retrieval with a chat reply.
+
+    1. `recall`  — delegates to oa://prime-vector/memory-retriever to search
+       the external memory store for turns relevant to the user's message.
+       Returns `history` and `memory_count`.
+
+    2. `respond` — delegates to the local chat-agent spec.  It depends_on
+       `recall`, so the runner merges recall's output (including `history`)
+       into respond's input automatically before the model is called.
+
+    OAS never stores or manages memory — the memory store is external
+    infrastructure.  This spec is purely a declarative retrieval + reply
+    pipeline.
+  role: assistant
+
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+
+tasks:
+  recall:
+    description: Retrieve relevant memory context for the user's message.
+    spec: oa://prime-vector/memory-retriever
+    task: retrieve
+
+  respond:
+    description: >
+      Reply to the user's message using retrieved memory context.
+      The `history` field from `recall` is merged in automatically.
+    depends_on:
+      - recall
+    spec: ../chat-agent/spec.yaml
+    task: chat

--- a/npm/src/providers/anthropic.ts
+++ b/npm/src/providers/anthropic.ts
@@ -1,4 +1,4 @@
-import type { ProviderConfig } from "../types.js";
+import type { ProviderConfig, ChatMessage } from "../types.js";
 import { OAError } from "../loader.js";
 
 const ANTHROPIC_BASE = "https://api.anthropic.com/v1";
@@ -8,6 +8,7 @@ export async function invokeAnthropic(
   system: string,
   user: string,
   config: ProviderConfig,
+  history?: ChatMessage[],
 ): Promise<string> {
   const apiKey = process.env["ANTHROPIC_API_KEY"];
   if (!apiKey) {
@@ -18,11 +19,15 @@ export async function invokeAnthropic(
     );
   }
 
+  const messages: ChatMessage[] = [];
+  if (history?.length) messages.push(...history);
+  messages.push({ role: "user", content: user });
+
   const extraConfig = (config.config ?? {}) as Record<string, unknown>;
   const body: Record<string, unknown> = {
     model: config.model,
     max_tokens: extraConfig["max_tokens"] ?? 4096,
-    messages: [{ role: "user", content: user }],
+    messages,
   };
   if (system) body["system"] = system;
   if (extraConfig["temperature"] !== undefined)

--- a/npm/src/providers/index.ts
+++ b/npm/src/providers/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderConfig } from "../types.js";
+import type { ProviderConfig, ChatMessage } from "../types.js";
 import { OAError } from "../loader.js";
 import { invokeOpenAI } from "./openai.js";
 import { invokeAnthropic } from "./anthropic.js";
@@ -10,14 +10,15 @@ export async function invokeProvider(
   system: string,
   user: string,
   config: ProviderConfig,
+  history?: ChatMessage[],
 ): Promise<string> {
   const engine = config.engine.toLowerCase();
 
   if (OPENAI_COMPATIBLE.has(engine)) {
-    return invokeOpenAI(system, user, config);
+    return invokeOpenAI(system, user, config, history);
   }
   if (ANTHROPIC_COMPATIBLE.has(engine)) {
-    return invokeAnthropic(system, user, config);
+    return invokeAnthropic(system, user, config, history);
   }
 
   throw new OAError(

--- a/npm/src/providers/openai.ts
+++ b/npm/src/providers/openai.ts
@@ -20,6 +20,7 @@ export async function invokeOpenAI(
   system: string,
   user: string,
   config: ProviderConfig,
+  history?: ChatMessage[],
 ): Promise<string> {
   const engine = config.engine.toLowerCase();
   const base = ENGINE_BASES[engine] ?? DEFAULT_BASE;
@@ -36,6 +37,7 @@ export async function invokeOpenAI(
 
   const messages: ChatMessage[] = [];
   if (system) messages.push({ role: "system", content: system });
+  if (history?.length) messages.push(...history);
   messages.push({ role: "user", content: user });
 
   const extraConfig = (config.config ?? {}) as Record<string, unknown>;

--- a/npm/src/runner.ts
+++ b/npm/src/runner.ts
@@ -154,7 +154,12 @@ async function runSingleTask(
     config: spec.intelligence.config,
   };
 
-  const raw = await invokeProvider(prompts.system, prompts.user, providerConfig);
+  // history is a reserved input convention — never stored by OAS, just forwarded.
+  const history = Array.isArray(input["history"])
+    ? (input["history"] as import("./types.js").ChatMessage[])
+    : undefined;
+
+  const raw = await invokeProvider(prompts.system, prompts.user, providerConfig, history);
   const output = extractJson(raw);
 
   return {

--- a/oas_cli/providers/anthropic_http.py
+++ b/oas_cli/providers/anthropic_http.py
@@ -26,7 +26,14 @@ class AnthropicProvider(IntelligenceProvider):
     Reads ANTHROPIC_API_KEY from the environment (or api_key_env in the spec).
     """
 
-    def invoke(self, *, system: str, user: str, config: dict) -> str:
+    def invoke(
+        self,
+        *,
+        system: str,
+        user: str,
+        config: dict,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
         api_key_env = config.get("api_key_env", "ANTHROPIC_API_KEY")
         api_key = os.environ.get(api_key_env)
         if not api_key:
@@ -44,9 +51,14 @@ class AnthropicProvider(IntelligenceProvider):
         max_tokens = int(config.get("max_tokens", 1000))
         timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
 
+        messages: list[dict[str, Any]] = []
+        if history:
+            messages.extend(history)
+        messages.append({"role": "user", "content": user})
+
         payload: dict[str, Any] = {
             "model": model,
-            "messages": [{"role": "user", "content": user}],
+            "messages": messages,
             "max_tokens": max_tokens,
             "temperature": temperature,
         }

--- a/oas_cli/providers/base.py
+++ b/oas_cli/providers/base.py
@@ -25,13 +25,24 @@ class IntelligenceProvider(ABC):
     """
 
     @abstractmethod
-    def invoke(self, *, system: str, user: str, config: dict) -> str:
+    def invoke(
+        self,
+        *,
+        system: str,
+        user: str,
+        config: dict,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
         """Invoke the model and return the raw text response.
 
         Args:
-            system: System prompt.
-            user:   User message (template already rendered).
-            config: Provider config dict from intelligence_config (model, temperature, …).
+            system:  System prompt.
+            user:    User message (template already rendered).
+            config:  Provider config dict from intelligence_config (model, temperature, …).
+            history: Optional prior-turn messages in OpenAI wire format
+                     ``[{"role": "user"|"assistant", "content": "…"}, …]``.
+                     Injected between the system message and the current user turn.
+                     OAS never stores history — callers pass it in via ``input.history``.
 
         Returns:
             Raw string output from the model — no parsing.

--- a/oas_cli/providers/codex.py
+++ b/oas_cli/providers/codex.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from .base import IntelligenceProvider, ProviderError
 
 
@@ -10,9 +12,17 @@ class CodexProvider(IntelligenceProvider):
 
     Merges system and user into a single prompt string because the codex adapter
     accepts a flat prompt rather than separate roles.
+    History is not forwarded — the Codex adapter uses a flat single-turn prompt.
     """
 
-    def invoke(self, *, system: str, user: str, config: dict) -> str:
+    def invoke(
+        self,
+        *,
+        system: str,
+        user: str,
+        config: dict,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
         try:
             from oas_cli.adapters import (
                 codex_adapter,  # local import avoids circular dep

--- a/oas_cli/providers/custom.py
+++ b/oas_cli/providers/custom.py
@@ -41,11 +41,22 @@ class CustomProvider(IntelligenceProvider):
                 system=system, user=user, config=config, history=history
             )
 
-        return self._invoke_class(module_path, system, user, config)
+        return self._invoke_class(module_path, system, user, config, history)
 
     @staticmethod
-    def _invoke_class(module_path: str, system: str, user: str, config: dict) -> str:
-        """Dynamically load ``module_path`` and call ``run()`` on an instance."""
+    def _invoke_class(
+        module_path: str,
+        system: str,
+        user: str,
+        config: dict,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
+        """Dynamically load ``module_path`` and call ``run()`` on an instance.
+
+        Custom router classes use a flat single-string prompt interface.
+        History turns are serialised and prepended to that prompt so
+        conversation context is not silently lost.
+        """
         if "." not in module_path:
             raise ProviderError(
                 f"intelligence.module must be 'module.ClassName', got: '{module_path}'"
@@ -75,7 +86,17 @@ class CustomProvider(IntelligenceProvider):
             ) from exc
 
         # The legacy interface takes a single merged prompt string.
-        prompt = f"{system}\n\n{user}".strip() if system else user
+        # Prepend history turns so context is not silently dropped.
+        parts: list[str] = []
+        if system:
+            parts.append(system)
+        if history:
+            for turn in history:
+                role = turn.get("role", "user").capitalize()
+                content = turn.get("content", "")
+                parts.append(f"{role}: {content}")
+        parts.append(user)
+        prompt = "\n\n".join(parts)
         try:
             result = router.run(prompt)
         except Exception as exc:

--- a/oas_cli/providers/custom.py
+++ b/oas_cli/providers/custom.py
@@ -15,6 +15,7 @@ When ``module`` is absent the provider falls back to the ``OpenAIProvider``
 from __future__ import annotations
 
 import importlib
+from typing import Any
 
 from .base import IntelligenceProvider, ProviderError
 
@@ -22,14 +23,23 @@ from .base import IntelligenceProvider, ProviderError
 class CustomProvider(IntelligenceProvider):
     """Routes to a user-supplied Python class, or falls back to HTTP."""
 
-    def invoke(self, *, system: str, user: str, config: dict) -> str:
+    def invoke(
+        self,
+        *,
+        system: str,
+        user: str,
+        config: dict,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
         module_path: str | None = config.get("module")
 
         if not module_path:
             # No module specified — behave as a plain OpenAI-compatible endpoint.
             from .openai_http import OpenAIProvider
 
-            return OpenAIProvider().invoke(system=system, user=user, config=config)
+            return OpenAIProvider().invoke(
+                system=system, user=user, config=config, history=history
+            )
 
         return self._invoke_class(module_path, system, user, config)
 

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -61,7 +61,9 @@ class OpenAIProvider(IntelligenceProvider):
         timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
 
         if endpoint.endswith("/responses"):
-            payload = _build_responses_payload(system, user, model, temperature, history)
+            payload = _build_responses_payload(
+                system, user, model, temperature, history
+            )
         else:
             payload = _build_chat_completions_payload(
                 system, user, model, temperature, max_tokens, history

--- a/oas_cli/providers/openai_http.py
+++ b/oas_cli/providers/openai_http.py
@@ -28,7 +28,14 @@ class OpenAIProvider(IntelligenceProvider):
     Reads OPENAI_API_KEY from the environment (or api_key_env in the spec).
     """
 
-    def invoke(self, *, system: str, user: str, config: dict) -> str:
+    def invoke(
+        self,
+        *,
+        system: str,
+        user: str,
+        config: dict,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
         api_key_env: str | None = config.get("api_key_env", "OPENAI_API_KEY")
         api_key: str | None = os.environ.get(api_key_env) if api_key_env else None
 
@@ -54,10 +61,10 @@ class OpenAIProvider(IntelligenceProvider):
         timeout = int(config.get("timeout", _DEFAULT_TIMEOUT))
 
         if endpoint.endswith("/responses"):
-            payload = _build_responses_payload(system, user, model, temperature)
+            payload = _build_responses_payload(system, user, model, temperature, history)
         else:
             payload = _build_chat_completions_payload(
-                system, user, model, temperature, max_tokens
+                system, user, model, temperature, max_tokens, history
             )
 
         extra_headers: dict[str, str] = {}
@@ -134,28 +141,39 @@ class OpenAIProvider(IntelligenceProvider):
 
 
 def _build_chat_completions_payload(
-    system: str, user: str, model: str, temperature: float, max_tokens: int
+    system: str,
+    user: str,
+    model: str,
+    temperature: float,
+    max_tokens: int,
+    history: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    messages: list[dict[str, Any]] = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history)
+    messages.append({"role": "user", "content": user})
     return {
         "model": model,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
+        "messages": messages,
         "temperature": temperature,
         "max_tokens": max_tokens,
     }
 
 
 def _build_responses_payload(
-    system: str, user: str, model: str, temperature: float
+    system: str,
+    user: str,
+    model: str,
+    temperature: float,
+    history: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    turns: list[dict[str, Any]] = [{"role": "system", "content": system}]
+    if history:
+        turns.extend(history)
+    turns.append({"role": "user", "content": user})
     return {
         "model": model,
-        "input": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
+        "input": turns,
         "temperature": temperature,
     }
 

--- a/oas_cli/providers/registry.py
+++ b/oas_cli/providers/registry.py
@@ -110,7 +110,9 @@ def invoke_intelligence(
     resolved = {**defaults, **config}
     provider = get_provider(resolved)
     return _with_retry(
-        lambda: provider.invoke(system=system, user=user, config=resolved, history=history)
+        lambda: provider.invoke(
+            system=system, user=user, config=resolved, history=history
+        )
     )
 
 

--- a/oas_cli/providers/registry.py
+++ b/oas_cli/providers/registry.py
@@ -76,7 +76,12 @@ def get_provider(config: dict) -> IntelligenceProvider:
     )
 
 
-def invoke_intelligence(system: str, user: str, config: dict) -> str:
+def invoke_intelligence(
+    system: str,
+    user: str,
+    config: dict,
+    history: list[dict] | None = None,
+) -> str:
     """Select the right provider and call it with retry.
 
     Engine-specific defaults are applied here so that ``get_provider`` and the
@@ -84,9 +89,13 @@ def invoke_intelligence(system: str, user: str, config: dict) -> str:
     defaults — later dict keys win in Python's ``{**defaults, **config}``).
 
     Args:
-        system: System prompt string.
-        user:   Rendered user prompt string.
-        config: Intelligence config produced by ``_build_intelligence_config``.
+        system:  System prompt string.
+        user:    Rendered user prompt string.
+        config:  Intelligence config produced by ``_build_intelligence_config``.
+        history: Optional prior-turn messages (OpenAI wire format).
+                 When provided, they are inserted between the system message and
+                 the current user turn.  OAS never stores or manages history —
+                 it is simply forwarded from ``input.history``.
 
     Returns:
         Raw string response from the model.
@@ -101,7 +110,7 @@ def invoke_intelligence(system: str, user: str, config: dict) -> str:
     resolved = {**defaults, **config}
     provider = get_provider(resolved)
     return _with_retry(
-        lambda: provider.invoke(system=system, user=user, config=resolved)
+        lambda: provider.invoke(system=system, user=user, config=resolved, history=history)
     )
 
 

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -449,6 +449,7 @@ def _invoke_with_tools(
     tools: list,
     intelligence_config: dict[str, Any],
     task_name: str,
+    history: list[dict] | None = None,
 ) -> str:
     """Multi-turn tool-call loop.
 
@@ -459,6 +460,9 @@ def _invoke_with_tools(
 
     Falls back to a single ``invoke_intelligence`` call when the selected provider
     does not support tool use natively (e.g. Codex adapter).
+
+    ``history`` is injected before the current user turn, mirroring the behaviour
+    of the no-tools path so conversation context is never lost.
     """
     provider = get_provider(intelligence_config)
 
@@ -472,9 +476,13 @@ def _invoke_with_tools(
         augmented_system = (
             f"{system}\n\nYou have access to the following tools:\n{tool_descriptions}"
         )
-        return invoke_intelligence(augmented_system, user, intelligence_config)
+        return invoke_intelligence(augmented_system, user, intelligence_config, history)
 
-    messages: list[dict[str, Any]] = [{"role": "user", "content": user}]
+    # Seed the message list: prior turns first, then current user turn.
+    messages: list[dict[str, Any]] = []
+    if history:
+        messages.extend(history)
+    messages.append({"role": "user", "content": user})
 
     for iteration in range(_MAX_TOOL_ITERATIONS):
         result: InvokeResult = provider.invoke_with_tools(
@@ -676,7 +684,7 @@ def _run_single_task(
         tools = resolve_task_tools(spec_data, task_name)
         if tools:
             raw_output = _invoke_with_tools(
-                system, user, tools, intelligence_config, task_name
+                system, user, tools, intelligence_config, task_name, history
             )
         else:
             raw_output = invoke_intelligence(system, user, intelligence_config, history)

--- a/oas_cli/runner.py
+++ b/oas_cli/runner.py
@@ -669,6 +669,9 @@ def _run_single_task(
     )
     intelligence_config = _build_intelligence_config(spec_data)
 
+    # history is a reserved input convention — never stored by OAS, just forwarded.
+    history: list[dict] | None = input_data.get("history") or None
+
     try:
         tools = resolve_task_tools(spec_data, task_name)
         if tools:
@@ -676,7 +679,7 @@ def _run_single_task(
                 system, user, tools, intelligence_config, task_name
             )
         else:
-            raw_output = invoke_intelligence(system, user, intelligence_config)
+            raw_output = invoke_intelligence(system, user, intelligence_config, history)
     except (ProviderError, ToolError) as exc:
         raise OARunError(
             str(exc),

--- a/tests/test_history_threading.py
+++ b/tests/test_history_threading.py
@@ -319,13 +319,13 @@ tasks:
             return '{"reply": "ok"}'
 
         # Stub resolve_task_tools to return a non-empty list without needing real tools.
-        FAKE_TOOL = object()
+        fake_tool = object()
 
         monkeypatch.setenv("OPENAI_API_KEY", "k")
         import oas_cli.runner as runner_mod
 
         monkeypatch.setattr(runner_mod, "_invoke_with_tools", fake_invoke_with_tools)
-        monkeypatch.setattr(runner_mod, "resolve_task_tools", lambda *_: [FAKE_TOOL])
+        monkeypatch.setattr(runner_mod, "resolve_task_tools", lambda *_: [fake_tool])
 
         from oas_cli.runner import run_task_from_file
 
@@ -347,13 +347,13 @@ tasks:
             received["history"] = history
             return '{"reply": "ok"}'
 
-        FAKE_TOOL = object()
+        fake_tool = object()
 
         monkeypatch.setenv("OPENAI_API_KEY", "k")
         import oas_cli.runner as runner_mod
 
         monkeypatch.setattr(runner_mod, "_invoke_with_tools", fake_invoke_with_tools)
-        monkeypatch.setattr(runner_mod, "resolve_task_tools", lambda *_: [FAKE_TOOL])
+        monkeypatch.setattr(runner_mod, "resolve_task_tools", lambda *_: [fake_tool])
 
         from oas_cli.runner import run_task_from_file
 

--- a/tests/test_history_threading.py
+++ b/tests/test_history_threading.py
@@ -2,18 +2,15 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
 from oas_cli.providers.openai_http import (
+    OpenAIProvider,
     _build_chat_completions_payload,
     _build_responses_payload,
 )
-from oas_cli.providers.anthropic_http import AnthropicProvider
-from oas_cli.providers.openai_http import OpenAIProvider
 from oas_cli.providers.registry import invoke_intelligence
 
 # ---------------------------------------------------------------------------
@@ -79,7 +76,7 @@ class TestOpenAIProviderHistory:
     def test_history_forwarded_to_payload(self, monkeypatch):
         captured: dict = {}
 
-        def fake_http_post(url, payload, headers, timeout):  # noqa: ARG001
+        def fake_http_post(url, payload, headers, timeout):
             captured["payload"] = payload
             return '{"choices":[{"message":{"content":"{\\"reply\\":\\"ok\\"}"}}]}'
 
@@ -92,7 +89,10 @@ class TestOpenAIProviderHistory:
             system="sys",
             user="hello again",
             config={"engine": "openai", "model": "gpt-4o-mini"},
-            history=[{"role": "user", "content": "first"}, {"role": "assistant", "content": "reply"}],
+            history=[
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply"},
+            ],
         )
 
         msgs = captured["payload"]["messages"]
@@ -207,7 +207,9 @@ tasks:
             {"role": "user", "content": "first message"},
             {"role": "assistant", "content": "first reply"},
         ]
-        result = run_task_from_file(chat_spec, "chat", {"message": "second", "history": history})
+        result = run_task_from_file(
+            chat_spec, "chat", {"message": "second", "history": history}
+        )
 
         assert result["output"]["reply"] == "got it"
         assert received["history"] == history

--- a/tests/test_history_threading.py
+++ b/tests/test_history_threading.py
@@ -248,3 +248,110 @@ tasks:
         run_task_from_file(chat_spec, "chat", {"message": "hello", "history": []})
         # empty list → treated as None (no history)
         assert not received["history"]
+
+
+# ---------------------------------------------------------------------------
+# Tools + history: history must not be silently dropped when tools are active
+# ---------------------------------------------------------------------------
+
+
+class TestToolsHistoryThreading:
+    """Regression test: history must reach the provider even when tools are active."""
+
+    @pytest.fixture()
+    def tool_spec(self, tmp_path: Path) -> Path:
+        spec = tmp_path / "tool_chat.yaml"
+        spec.write_text(
+            """
+open_agent_spec: "1.4.0"
+agent:
+  name: tool-chat
+  role: assistant
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+tools:
+  echo:
+    type: native
+    native: echo
+    description: Echo text back
+    input_schema:
+      type: object
+      properties:
+        text: {type: string}
+      required: [text]
+tasks:
+  chat:
+    tools: [echo]
+    input:
+      type: object
+      properties:
+        message: {type: string}
+        history:
+          type: array
+          items:
+            type: object
+            properties:
+              role: {type: string}
+              content: {type: string}
+      required: [message]
+    output:
+      type: object
+      properties:
+        reply: {type: string}
+      required: [reply]
+    prompts:
+      system: You are helpful.
+      user: "{message}"
+"""
+        )
+        return spec
+
+    def test_history_forwarded_to_invoke_with_tools(
+        self, tool_spec: Path, monkeypatch
+    ):
+        """History must be passed into _invoke_with_tools, not silently dropped."""
+        received: dict = {}
+
+        def fake_invoke_with_tools(system, user, tools, config, task_name, history=None):
+            received["history"] = history
+            return '{"reply": "ok"}'
+
+        # Stub resolve_task_tools to return a non-empty list without needing real tools.
+        FAKE_TOOL = object()
+
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        import oas_cli.runner as runner_mod
+
+        monkeypatch.setattr(runner_mod, "_invoke_with_tools", fake_invoke_with_tools)
+        monkeypatch.setattr(runner_mod, "resolve_task_tools", lambda *_: [FAKE_TOOL])
+
+        from oas_cli.runner import run_task_from_file
+
+        history = [
+            {"role": "user", "content": "earlier message"},
+            {"role": "assistant", "content": "earlier reply"},
+        ]
+        run_task_from_file(tool_spec, "chat", {"message": "new message", "history": history})
+        assert received["history"] == history
+
+    def test_no_history_tools_path_passes_none(self, tool_spec: Path, monkeypatch):
+        received: dict = {}
+
+        def fake_invoke_with_tools(system, user, tools, config, task_name, history=None):
+            received["history"] = history
+            return '{"reply": "ok"}'
+
+        FAKE_TOOL = object()
+
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        import oas_cli.runner as runner_mod
+
+        monkeypatch.setattr(runner_mod, "_invoke_with_tools", fake_invoke_with_tools)
+        monkeypatch.setattr(runner_mod, "resolve_task_tools", lambda *_: [FAKE_TOOL])
+
+        from oas_cli.runner import run_task_from_file
+
+        run_task_from_file(tool_spec, "chat", {"message": "hello"})
+        assert received["history"] is None

--- a/tests/test_history_threading.py
+++ b/tests/test_history_threading.py
@@ -143,6 +143,80 @@ class TestInvokeIntelligenceHistory:
 
 
 # ---------------------------------------------------------------------------
+# CustomProvider._invoke_class history forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestCustomProviderHistory:
+    """History must be forwarded to custom router classes via the merged prompt."""
+
+    def _make_router_class(self, captured: dict):
+        """Return a minimal router class that records the prompt it receives."""
+
+        class FakeRouter:
+            def __init__(self, endpoint, model, config):
+                pass
+
+            def run(self, prompt: str) -> str:
+                captured["prompt"] = prompt
+                return '{"reply": "ok"}'
+
+        return FakeRouter
+
+    def test_history_prepended_to_merged_prompt(self, monkeypatch):
+        from oas_cli.providers.custom import CustomProvider
+
+        captured: dict = {}
+        router_cls = self._make_router_class(captured)
+
+        monkeypatch.setattr(
+            "importlib.import_module",
+            lambda name: type("mod", (), {"FakeRouter": router_cls})(),
+        )
+
+        CustomProvider._invoke_class(
+            "fake_module.FakeRouter",
+            system="You are helpful.",
+            user="What is the answer?",
+            config={},
+            history=[
+                {"role": "user", "content": "prior question"},
+                {"role": "assistant", "content": "prior answer"},
+            ],
+        )
+
+        prompt = captured["prompt"]
+        assert "prior question" in prompt
+        assert "prior answer" in prompt
+        # History must come between system and current user turn
+        assert prompt.index("prior question") < prompt.index("What is the answer?")
+
+    def test_no_history_omits_history_section(self, monkeypatch):
+        from oas_cli.providers.custom import CustomProvider
+
+        captured: dict = {}
+        router_cls = self._make_router_class(captured)
+
+        monkeypatch.setattr(
+            "importlib.import_module",
+            lambda name: type("mod", (), {"FakeRouter": router_cls})(),
+        )
+
+        CustomProvider._invoke_class(
+            "fake_module.FakeRouter",
+            system="You are helpful.",
+            user="Hello",
+            config={},
+            history=None,
+        )
+
+        prompt = captured["prompt"]
+        assert "User:" not in prompt
+        assert "Assistant:" not in prompt
+        assert "Hello" in prompt
+
+
+# ---------------------------------------------------------------------------
 # Runner integration: history extracted from input_data
 # ---------------------------------------------------------------------------
 

--- a/tests/test_history_threading.py
+++ b/tests/test_history_threading.py
@@ -308,13 +308,13 @@ tasks:
         )
         return spec
 
-    def test_history_forwarded_to_invoke_with_tools(
-        self, tool_spec: Path, monkeypatch
-    ):
+    def test_history_forwarded_to_invoke_with_tools(self, tool_spec: Path, monkeypatch):
         """History must be passed into _invoke_with_tools, not silently dropped."""
         received: dict = {}
 
-        def fake_invoke_with_tools(system, user, tools, config, task_name, history=None):
+        def fake_invoke_with_tools(
+            system, user, tools, config, task_name, history=None
+        ):
             received["history"] = history
             return '{"reply": "ok"}'
 
@@ -333,13 +333,17 @@ tasks:
             {"role": "user", "content": "earlier message"},
             {"role": "assistant", "content": "earlier reply"},
         ]
-        run_task_from_file(tool_spec, "chat", {"message": "new message", "history": history})
+        run_task_from_file(
+            tool_spec, "chat", {"message": "new message", "history": history}
+        )
         assert received["history"] == history
 
     def test_no_history_tools_path_passes_none(self, tool_spec: Path, monkeypatch):
         received: dict = {}
 
-        def fake_invoke_with_tools(system, user, tools, config, task_name, history=None):
+        def fake_invoke_with_tools(
+            system, user, tools, config, task_name, history=None
+        ):
             received["history"] = history
             return '{"reply": "ok"}'
 

--- a/tests/test_history_threading.py
+++ b/tests/test_history_threading.py
@@ -1,0 +1,248 @@
+"""Tests for history threading — OAS injects prior turns between system and user."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oas_cli.providers.openai_http import (
+    _build_chat_completions_payload,
+    _build_responses_payload,
+)
+from oas_cli.providers.anthropic_http import AnthropicProvider
+from oas_cli.providers.openai_http import OpenAIProvider
+from oas_cli.providers.registry import invoke_intelligence
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsPayloadHistory:
+    def test_no_history_produces_two_messages(self):
+        payload = _build_chat_completions_payload(
+            "sys", "user msg", "gpt-4o-mini", 0.7, 1000
+        )
+        msgs = payload["messages"]
+        assert len(msgs) == 2
+        assert msgs[0] == {"role": "system", "content": "sys"}
+        assert msgs[1] == {"role": "user", "content": "user msg"}
+
+    def test_history_injected_between_system_and_user(self):
+        history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        payload = _build_chat_completions_payload(
+            "sys", "follow-up", "gpt-4o-mini", 0.7, 1000, history
+        )
+        msgs = payload["messages"]
+        assert len(msgs) == 4
+        assert msgs[0] == {"role": "system", "content": "sys"}
+        assert msgs[1] == {"role": "user", "content": "hi"}
+        assert msgs[2] == {"role": "assistant", "content": "hello"}
+        assert msgs[3] == {"role": "user", "content": "follow-up"}
+
+    def test_empty_history_list_treated_as_no_history(self):
+        payload = _build_chat_completions_payload(
+            "sys", "msg", "gpt-4o-mini", 0.7, 1000, []
+        )
+        assert len(payload["messages"]) == 2
+
+    def test_none_history_treated_as_no_history(self):
+        payload = _build_chat_completions_payload(
+            "sys", "msg", "gpt-4o-mini", 0.7, 1000, None
+        )
+        assert len(payload["messages"]) == 2
+
+
+class TestResponsesPayloadHistory:
+    def test_history_injected_into_responses_payload(self):
+        history = [{"role": "user", "content": "prev"}]
+        payload = _build_responses_payload("sys", "cur", "gpt-4o-mini", 0.7, history)
+        turns = payload["input"]
+        assert turns[0]["role"] == "system"
+        assert turns[1]["role"] == "user"
+        assert turns[1]["content"] == "prev"
+        assert turns[2]["content"] == "cur"
+
+
+# ---------------------------------------------------------------------------
+# Provider-level: OpenAIProvider.invoke passes history
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProviderHistory:
+    def test_history_forwarded_to_payload(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_http_post(url, payload, headers, timeout):  # noqa: ARG001
+            captured["payload"] = payload
+            return '{"choices":[{"message":{"content":"{\\"reply\\":\\"ok\\"}"}}]}'
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        import oas_cli.providers.openai_http as m
+
+        monkeypatch.setattr(m, "_http_post", fake_http_post)
+
+        OpenAIProvider().invoke(
+            system="sys",
+            user="hello again",
+            config={"engine": "openai", "model": "gpt-4o-mini"},
+            history=[{"role": "user", "content": "first"}, {"role": "assistant", "content": "reply"}],
+        )
+
+        msgs = captured["payload"]["messages"]
+        assert msgs[1]["content"] == "first"
+        assert msgs[2]["content"] == "reply"
+        assert msgs[3]["content"] == "hello again"
+
+
+# ---------------------------------------------------------------------------
+# Provider registry: invoke_intelligence threads history
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeIntelligenceHistory:
+    def test_history_passed_through_to_provider(self, monkeypatch):
+        received: dict = {}
+
+        class MockProvider:
+            def invoke(self, *, system, user, config, history=None):
+                received["history"] = history
+                return '{"reply": "ok"}'
+
+        monkeypatch.setattr(
+            "oas_cli.providers.registry.get_provider",
+            lambda _config: MockProvider(),
+        )
+
+        history = [{"role": "user", "content": "turn 1"}]
+        invoke_intelligence("sys", "user", {"engine": "openai"}, history)
+
+        assert received["history"] == history
+
+    def test_no_history_passes_none(self, monkeypatch):
+        received: dict = {}
+
+        class MockProvider:
+            def invoke(self, *, system, user, config, history=None):
+                received["history"] = history
+                return '{"reply": "ok"}'
+
+        monkeypatch.setattr(
+            "oas_cli.providers.registry.get_provider",
+            lambda _config: MockProvider(),
+        )
+
+        invoke_intelligence("sys", "user", {"engine": "openai"})
+        assert received["history"] is None
+
+
+# ---------------------------------------------------------------------------
+# Runner integration: history extracted from input_data
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerHistoryExtraction:
+    """Verify the runner picks up `history` from input_data and forwards it."""
+
+    @pytest.fixture()
+    def chat_spec(self, tmp_path: Path) -> Path:
+        spec = tmp_path / "chat.yaml"
+        spec.write_text(
+            """
+open_agent_spec: "1.4.0"
+agent:
+  name: chat-agent
+  role: assistant
+intelligence:
+  type: llm
+  engine: openai
+  model: gpt-4o-mini
+tasks:
+  chat:
+    input:
+      type: object
+      properties:
+        message: {type: string}
+        history:
+          type: array
+          items:
+            type: object
+            properties:
+              role: {type: string}
+              content: {type: string}
+      required: [message]
+    output:
+      type: object
+      properties:
+        reply: {type: string}
+      required: [reply]
+    prompts:
+      system: You are helpful.
+      user: "{message}"
+"""
+        )
+        return spec
+
+    def test_history_forwarded_from_input(self, chat_spec: Path, monkeypatch):
+        received: dict = {}
+
+        def fake_invoke(system, user, config, history=None):
+            received["history"] = history
+            return '{"reply": "got it"}'
+
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        import oas_cli.runner as runner_mod
+
+        monkeypatch.setattr(runner_mod, "invoke_intelligence", fake_invoke)
+
+        from oas_cli.runner import run_task_from_file
+
+        history = [
+            {"role": "user", "content": "first message"},
+            {"role": "assistant", "content": "first reply"},
+        ]
+        result = run_task_from_file(chat_spec, "chat", {"message": "second", "history": history})
+
+        assert result["output"]["reply"] == "got it"
+        assert received["history"] == history
+
+    def test_no_history_in_input_passes_none(self, chat_spec: Path, monkeypatch):
+        received: dict = {}
+
+        def fake_invoke(system, user, config, history=None):
+            received["history"] = history
+            return '{"reply": "ok"}'
+
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        import oas_cli.runner as runner_mod
+
+        monkeypatch.setattr(runner_mod, "invoke_intelligence", fake_invoke)
+
+        from oas_cli.runner import run_task_from_file
+
+        run_task_from_file(chat_spec, "chat", {"message": "hello"})
+        assert received["history"] is None
+
+    def test_empty_history_list_passes_none(self, chat_spec: Path, monkeypatch):
+        received: dict = {}
+
+        def fake_invoke(system, user, config, history=None):
+            received["history"] = history
+            return '{"reply": "ok"}'
+
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        import oas_cli.runner as runner_mod
+
+        monkeypatch.setattr(runner_mod, "invoke_intelligence", fake_invoke)
+
+        from oas_cli.runner import run_task_from_file
+
+        run_task_from_file(chat_spec, "chat", {"message": "hello", "history": []})
+        # empty list → treated as None (no history)
+        assert not received["history"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -119,7 +119,7 @@ def test_run_system_prompt_override_reaches_runner(tmp_path):
     spec_file = _write_spec(tmp_path)
     captured: dict = {}
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         captured["prompt"] = f"{system}\n\n{user}"
         return '{"response": "hi"}'
 
@@ -151,7 +151,7 @@ def test_run_user_prompt_override_reaches_runner(tmp_path):
     spec_file = _write_spec(tmp_path)
     captured: dict = {}
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         captured["prompt"] = f"{system}\n\n{user}"
         return '{"response": "hi"}'
 
@@ -182,7 +182,7 @@ def test_run_no_overrides_uses_per_task_prompt(tmp_path):
     spec_file = _write_spec(tmp_path)
     captured: dict = {}
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         captured["prompt"] = f"{system}\n\n{user}"
         return '{"response": "hi"}'
 
@@ -210,7 +210,7 @@ def test_run_output_is_valid_json_in_quiet_mode(tmp_path):
     """oa run --quiet outputs valid JSON."""
     spec_file = _write_spec(tmp_path)
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         return '{"response": "Hello Alice!"}'
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):

--- a/tests/test_multi_task_workflows.py
+++ b/tests/test_multi_task_workflows.py
@@ -151,7 +151,7 @@ def _run(
     )
     captured: dict = {}
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         captured["prompt"] = f"{system}\n\n{user}"
         captured["config"] = config
         return resolved_response
@@ -579,7 +579,7 @@ class TestOutputNormalisation:
         """If invoke_intelligence returns a dict, pass it straight through."""
         spec = _spec({"t": _task(system="s", user="{{ q }}")})
 
-        def fake_invoke(system: str, user: str, config: dict) -> dict:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> dict:
             return {"result": "direct"}
 
         with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -985,7 +985,7 @@ def _cli_run(
 ) -> object:
     captured: dict = {}
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         captured["prompt"] = f"{system}\n\n{user}"
         return fake_response
 
@@ -1096,7 +1096,7 @@ class TestCLIIntegration:
         # Greet task has a single required string field — file should be accepted
         captured: dict = {}
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             captured["prompt"] = f"{system}\n\n{user}"
             return '{"response": "hi"}'
 
@@ -1125,7 +1125,7 @@ class TestCLIIntegration:
 
         captured: dict = {}
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             captured["prompt"] = f"{system}\n\n{user}"
             return '{"response": "hi"}'
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -77,7 +77,7 @@ class TestEngineDefaults:
         """Call invoke_intelligence and capture the resolved config passed to the provider."""
         captured: dict = {}
 
-        def fake_invoke(*, system, user, config):
+        def fake_invoke(*, system, user, config, history=None):
             captured.update(config)
             return '{"ok": true}'
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -313,7 +313,9 @@ class TestResponseFormatText:
     def test_text_mode_does_not_parse_fenced_json(self, monkeypatch):
         """Even fenced JSON should be returned as-is in text mode (no fence stripping)."""
         raw = '```json\n{"key": "val"}\n```'
-        monkeypatch.setattr("oas_cli.runner.invoke_intelligence", lambda s, u, c, h=None: raw)
+        monkeypatch.setattr(
+            "oas_cli.runner.invoke_intelligence", lambda s, u, c, h=None: raw
+        )
         result = run_task_from_spec(
             _text_spec(), task_name="prose", input_data={"topic": "x"}
         )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -233,7 +233,7 @@ class TestRunTaskFromSpecOverrides:
     def test_override_system_reaches_invoke(self, monkeypatch):
         captured: dict = {}
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             captured["prompt"] = f"{system}\n\n{user}"
             return '{"result": "ok"}'
 
@@ -252,7 +252,7 @@ class TestRunTaskFromSpecOverrides:
     def test_no_override_uses_spec_prompt(self, monkeypatch):
         captured: dict = {}
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             captured["prompt"] = f"{system}\n\n{user}"
             return '{"result": "ok"}'
 
@@ -292,7 +292,7 @@ class TestResponseFormatText:
     def test_text_mode_returns_raw_string(self, monkeypatch):
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: "This is plain prose output.",
+            lambda s, u, c, h=None: "This is plain prose output.",
         )
         result = run_task_from_spec(
             _text_spec(), task_name="prose", input_data={"topic": "cats"}
@@ -303,7 +303,7 @@ class TestResponseFormatText:
         """Raw output that is NOT valid JSON must be returned unchanged in text mode."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: "Not JSON at all { broken",
+            lambda s, u, c, h=None: "Not JSON at all { broken",
         )
         result = run_task_from_spec(
             _text_spec(), task_name="prose", input_data={"topic": "x"}
@@ -313,7 +313,7 @@ class TestResponseFormatText:
     def test_text_mode_does_not_parse_fenced_json(self, monkeypatch):
         """Even fenced JSON should be returned as-is in text mode (no fence stripping)."""
         raw = '```json\n{"key": "val"}\n```'
-        monkeypatch.setattr("oas_cli.runner.invoke_intelligence", lambda s, u, c: raw)
+        monkeypatch.setattr("oas_cli.runner.invoke_intelligence", lambda s, u, c, h=None: raw)
         result = run_task_from_spec(
             _text_spec(), task_name="prose", input_data={"topic": "x"}
         )
@@ -323,7 +323,7 @@ class TestResponseFormatText:
         """response_format: json (default) still parses JSON as before."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: '{"result": "ok"}',
+            lambda s, u, c, h=None: '{"result": "ok"}',
         )
         result = run_task_from_spec(
             _text_spec("json"), task_name="prose", input_data={"topic": "x"}
@@ -335,7 +335,7 @@ class TestResponseFormatText:
         spec = _spec(global_system="sys", global_user="{{ q }}")
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: '{"result": "fine"}',
+            lambda s, u, c, h=None: '{"result": "fine"}',
         )
         result = run_task_from_spec(spec, task_name="mytask", input_data={"q": "hi"})
         assert result["output"] == {"result": "fine"}
@@ -372,7 +372,7 @@ class TestOARunError:
         assert err.task == "missing"
 
     def test_invoke_error_wrapped_in_oa_run_error(self, monkeypatch):
-        def bad_invoke(s, u, c):
+        def bad_invoke(s, u, c, h=None):
             raise RuntimeError("network timeout")
 
         monkeypatch.setattr("oas_cli.runner.invoke_intelligence", bad_invoke)
@@ -423,7 +423,7 @@ class TestDependsOn:
     def test_chain_executes_dependency_first(self, monkeypatch):
         calls: list[str] = []
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             if "extract" in user or calls == []:
                 calls.append("extract")
                 return '{"facts": "the sky is blue"}'
@@ -441,7 +441,7 @@ class TestDependsOn:
         """Facts from extract must appear in summarize's prompt."""
         prompts_seen: list[str] = []
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             prompts_seen.append(f"{system}\n\n{user}")
             if len(prompts_seen) == 1:
                 return '{"facts": "the sky is blue"}'
@@ -457,7 +457,7 @@ class TestDependsOn:
         """When both base input and dep output have the same key, dep output wins."""
         prompts_seen: list[str] = []
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             prompts_seen.append(f"{system}\n\n{user}")
             if len(prompts_seen) == 1:
                 return '{"facts": "from dep"}'
@@ -475,7 +475,7 @@ class TestDependsOn:
     def test_chain_result_includes_intermediate(self, monkeypatch):
         calls = {"n": 0}
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             calls["n"] += 1
             if calls["n"] == 1:
                 return '{"facts": "extracted facts"}'
@@ -491,7 +491,7 @@ class TestDependsOn:
         """Tasks with no depends_on must NOT add a chain key."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: '{"facts": "x"}',
+            lambda s, u, c, h=None: '{"facts": "x"}',
         )
         spec = _chain_spec()
         result = run_task_from_spec(spec, task_name="extract", input_data={})
@@ -503,7 +503,7 @@ class TestDependsOn:
         spec["tasks"]["summarize"]["depends_on"] = ["nonexistent"]
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: '{"facts": "x"}',
+            lambda s, u, c, h=None: '{"facts": "x"}',
         )
         with pytest.raises(OARunError) as exc_info:
             run_task_from_spec(spec, task_name="summarize", input_data={})
@@ -515,7 +515,7 @@ class TestDependsOn:
         spec["tasks"]["extract"]["depends_on"] = ["summarize"]
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: "{}",
+            lambda s, u, c, h=None: "{}",
         )
         with pytest.raises(OARunError) as exc_info:
             run_task_from_spec(spec, task_name="summarize", input_data={})
@@ -525,7 +525,7 @@ class TestDependsOn:
         """If required fields are still missing after merge, fail fast."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: "{}",  # dep returns empty output
+            lambda s, u, c, h=None: "{}",  # dep returns empty output
         )
         spec = _chain_spec()
         # Remove required from extract's output so empty {} passes output
@@ -696,7 +696,7 @@ class TestContractEnforcementLive:
     def test_valid_output_passes(self, monkeypatch):
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: '{"summary": "all good", "confidence": "high"}',
+            lambda s, u, c, h=None: '{"summary": "all good", "confidence": "high"}',
         )
         spec = self._contract_spec(["summary", "confidence"])
         result = run_task_from_spec(spec, task_name="mytask", input_data={"q": "hi"})
@@ -705,7 +705,7 @@ class TestContractEnforcementLive:
     def test_missing_required_field_raises_contract_violation(self, monkeypatch):
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: '{"summary": "ok"}',  # missing 'confidence'
+            lambda s, u, c, h=None: '{"summary": "ok"}',  # missing 'confidence'
         )
         spec = self._contract_spec(["summary", "confidence"])
         with pytest.raises(OARunError) as exc_info:
@@ -720,7 +720,7 @@ class TestContractEnforcementLive:
         """response_format: text must never raise CONTRACT_VIOLATION."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: "plain prose — no fields at all",
+            lambda s, u, c, h=None: "plain prose — no fields at all",
         )
         spec = self._contract_spec(["summary"], response_format="text")
         result = run_task_from_spec(spec, task_name="mytask", input_data={"q": "hi"})
@@ -730,7 +730,7 @@ class TestContractEnforcementLive:
         """Top-level contract applies when task has none of its own."""
         monkeypatch.setattr(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: '{"summary": "ok"}',  # missing global 'confidence'
+            lambda s, u, c, h=None: '{"summary": "ok"}',  # missing global 'confidence'
         )
         spec = {
             "open_agent_spec": "1.4.0",
@@ -762,7 +762,7 @@ class TestContractEnforcementLive:
         """Contract violation on a dependency must halt the chain before the main task runs."""
         calls: list[str] = []
 
-        def fake_invoke(system: str, user: str, config: dict) -> str:
+        def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
             calls.append(f"{system}\n\n{user}")
             return '{"wrong_field": "oops"}'  # missing 'facts'
 

--- a/tests/test_spec_composition.py
+++ b/tests/test_spec_composition.py
@@ -80,7 +80,7 @@ class TestBasicDelegation:
         _write_spec(tmp_path / "shared", "greeter.yaml", shared_spec)
         coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
 
-        def fake_invoke(system, user, config):
+        def fake_invoke(system, user, config, history=None):
             return json.dumps({"reply": "Hello there!"})
 
         with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -121,7 +121,7 @@ class TestBasicDelegation:
         _write_spec(tmp_path, "shared.yaml", shared_spec)
         coordinator_path = _write_spec(tmp_path, "coordinator.yaml", coordinator_spec)
 
-        def fake_invoke(system, user, config):
+        def fake_invoke(system, user, config, history=None):
             return json.dumps({"result": "done"})
 
         with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -161,7 +161,7 @@ class TestBasicDelegation:
 
         with patch(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: json.dumps({"summary": "brief"}),
+            lambda s, u, c, h=None: json.dumps({"summary": "brief"}),
         ):
             result = run_task_from_file(coordinator_path, task_name="summarise")
 
@@ -225,7 +225,7 @@ class TestDelegationWithChain:
 
         call_count = {"n": 0}
 
-        def fake_invoke(system, user, config):
+        def fake_invoke(system, user, config, history=None):
             call_count["n"] += 1
             if call_count["n"] == 1:
                 return json.dumps({"keywords": ["foo", "bar"]})
@@ -398,7 +398,7 @@ class TestDelegationErrors:
 
         with patch(
             "oas_cli.runner.invoke_intelligence",
-            lambda s, u, c: json.dumps({"pong": "ok"}),
+            lambda s, u, c, h=None: json.dumps({"pong": "ok"}),
         ):
             result = run_task_from_file(coordinator_path, task_name="ping")
 

--- a/tests/test_spec_test.py
+++ b/tests/test_spec_test.py
@@ -127,7 +127,7 @@ cases:
 """
     )
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         return json.dumps({"response": "Hello Bob from mock"})
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -154,7 +154,7 @@ cases:
 """
     )
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         return json.dumps({"response": "Hello x"})
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):
@@ -183,7 +183,7 @@ cases:
 """
     )
 
-    def fake_invoke(system: str, user: str, config: dict) -> str:
+    def fake_invoke(system: str, user: str, config: dict, history=None) -> str:
         return json.dumps({"response": "Hi Bob"})
 
     with patch("oas_cli.runner.invoke_intelligence", fake_invoke):


### PR DESCRIPTION
OAS is stateless — it never stores conversation history. This PR implements two clean memory patterns that respect that boundary:

History threading (short-term memory)
- `history` is now a reserved input convention: an array of prior turns in OpenAI wire format [{"role": "user"|"assistant", "content": "…"}]
- Python runner extracts `history` from input_data and passes it through the provider stack; injected between system prompt and current user message at the HTTP payload level
- npm runner (OpenAI + Anthropic providers) receives the same treatment
- All provider signatures updated: base.IntelligenceProvider.invoke, OpenAIProvider, AnthropicProvider, CodexProvider, CustomProvider, invoke_intelligence registry function
- 11 new tests in tests/test_history_threading.py; all existing test fake_invoke stubs updated to accept the optional history parameter

prime-vector/memory-retriever registry spec (long-term memory)
- New registry spec at Website/public/registry/prime-vector/memory-retriever/
- Accepts query, memory_store_url, top_k; calls external store; returns {history: [...turns], memory_count} ready for depends_on chaining
- Added to Website/public/registry/index.json manifest

New examples
- examples/chat-agent/: spec.yaml + chat.py REPL for session history
- examples/memory-chat/: pipeline.yaml chaining memory-retriever → chat via depends_on, plus README with mock memory-store script

docs/REFERENCE.md: new Memory management section covering both patterns, boundary table (what OAS does NOT do), and links to examples

## What changed

<!-- 1-3 sentences: what does this PR do? -->

## Why

<!-- Link to issue or explain the motivation -->

## How tested

<!-- Commands you ran, tests you wrote, or manual checks -->

- [ ] All existing tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring / CI / tooling

## Breaking changes

<!-- If none, delete this section. Otherwise list what breaks and migration steps. -->

## Checklist

- [ ] Code follows project style (`ruff check . && ruff format --check .`)
- [ ] Self-review completed
- [ ] Version bumped if needed (`pyproject.toml`, templates, docs)
